### PR TITLE
Refine milestones radiator interactions

### DIFF
--- a/milestones-radiator.html
+++ b/milestones-radiator.html
@@ -1,0 +1,441 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <!--
+    FlowingData-style Milestones Radiator
+    ------------------------------------
+    1. Update the `milestones` array in the <script> block below. Each object accepts:
+         - title (required, shown as the card title)
+         - url (required to make the title clickable)
+         - start (optional ISO date or date-time: "2024-06-01" or "2024-06-01T09:00")
+         - end (optional ISO date or date-time when the milestone finishes)
+         - category (optional short label for grouping; colors are assigned automatically)
+       Omit "start" to default the milestone to "now".
+
+    2. To embed this radiator inside an Azure DevOps Wiki page, open the file in a
+       browser, copy the full HTML (Ctrl+A, Ctrl+C) and paste it into the Wiki editor.
+       Azure DevOps will render the pasted HTML without extra steps.
+  -->
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Milestones Radiator</title>
+  <style>
+    :root {
+      --teal-100:#EAF6F4;
+      --teal-150:#D7ECE8;
+      --teal-200:#C2E3DD;
+      --teal-300:#9FD3C6;
+      --teal-600:#2A8C82;
+      --teal-700:#18786F;
+      --green-500:#33B990;
+      --gold-500:#F3C613;
+      --bg:#EAF6F4;
+      --panel:#FFFFFF;
+      --panel-soft:#F6FBFA;
+      --ink:#0F2D2E;
+      --muted:#5D7A7F;
+      --ring:#CFE0DC;
+      --shadow-elev:0 1px 2px rgba(6,44,40,.06),0 10px 24px rgba(6,44,40,.06);
+      --accent:#33B990;
+      --accent-2:#2A8C82;
+      --accent-3:#F3C613;
+      --accent-4:#0E5F5A;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font: 14px/1.45 system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,"Helvetica Neue",Arial,"Noto Sans";
+      background: var(--bg);
+      color: var(--ink);
+      padding: 32px 24px 64px;
+    }
+    h1 {
+      font-size: 28px;
+      margin: 0 0 4px;
+      color: var(--teal-700);
+    }
+    p.lead { margin: 0 0 24px; color: var(--muted); }
+    .radiator {
+      display: grid;
+      gap: 16px;
+    }
+    @media (min-width: 720px) {
+      .radiator {
+        grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      }
+    }
+    .milestone-card {
+      position: relative;
+      background: var(--panel);
+      border: 1px solid var(--ring);
+      border-radius: 14px;
+      padding: 20px 20px 24px;
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+      box-shadow: var(--shadow-elev);
+      transition: transform .2s ease, box-shadow .2s ease;
+    }
+    .milestone-card:hover {
+      transform: translateY(-2px);
+      box-shadow: 0 16px 32px rgba(10, 67, 63, .12);
+    }
+    .milestone-card::before {
+      content: "";
+      position: absolute;
+      inset: 0;
+      border-radius: inherit;
+      pointer-events: none;
+      border: 2px solid transparent;
+    }
+    .milestone-title {
+      font-size: 18px;
+      font-weight: 600;
+      margin: 0;
+      color: var(--teal-700);
+    }
+    .milestone-title a {
+      color: inherit;
+      text-decoration: none;
+    }
+    .milestone-title a:hover,
+    .milestone-title a:focus {
+      text-decoration: underline;
+    }
+    .milestone-meta {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px 12px;
+      align-items: center;
+      color: var(--muted);
+      font-size: 12px;
+    }
+    .badge {
+      padding: 2px 10px;
+      border-radius: 999px;
+      background: var(--panel-soft);
+      border: 1px solid var(--ring);
+      font-size: 11px;
+      letter-spacing: .02em;
+      text-transform: uppercase;
+    }
+    .status {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      font-size: 12px;
+      font-weight: 600;
+      letter-spacing: .02em;
+    }
+    .status-dot {
+      width: 8px;
+      height: 8px;
+      border-radius: 999px;
+      background: currentColor;
+    }
+    .progress-bar {
+      position: relative;
+      height: 10px;
+      background: var(--panel-soft);
+      border-radius: 999px;
+      border: 1px solid var(--ring);
+      overflow: hidden;
+    }
+    .progress-bar span {
+      position: absolute;
+      inset: 0;
+      width: var(--w, 0%);
+      background: linear-gradient(90deg, var(--accent), var(--accent-2));
+      border-radius: inherit;
+      transition: width .6s cubic-bezier(.22,.61,.36,1);
+    }
+    .dates {
+      display: grid;
+      gap: 4px;
+      font-size: 13px;
+      color: var(--muted);
+    }
+    .countdown {
+      font-size: 15px;
+      font-weight: 600;
+      color: var(--ink);
+    }
+    .milestone-card.pending::before {
+      border-color: rgba(47, 115, 110, .12);
+    }
+    .milestone-card.pending .status { color: var(--teal-600); }
+    .milestone-card.active::before {
+      border-color: rgba(51, 185, 144, .28);
+    }
+    .milestone-card.active .status { color: var(--green-500); }
+    .milestone-card.done::before {
+      border-color: rgba(93, 122, 127, .22);
+    }
+    .milestone-card.done .status { color: var(--muted); }
+    .milestone-card.done .progress-bar span {
+      background: linear-gradient(90deg, var(--teal-300), var(--teal-200));
+    }
+    time { font-variant-numeric: tabular-nums; }
+    .completed-wrapper {
+      margin-top: 32px;
+      border-top: 1px solid var(--ring);
+      padding-top: 24px;
+    }
+    .toggle-completed {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 10px 16px;
+      border-radius: 999px;
+      border: 1px solid var(--ring);
+      background: var(--panel);
+      color: var(--teal-700);
+      font-weight: 600;
+      cursor: pointer;
+      box-shadow: var(--shadow-elev);
+      transition: transform .2s ease, box-shadow .2s ease;
+    }
+    .toggle-completed:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 16px 32px rgba(10, 67, 63, .12);
+    }
+    .toggle-completed[aria-expanded="true"] {
+      background: var(--panel-soft);
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Milestones Radiator</h1>
+    <p class="lead">Track project momentum with a FlowingData-inspired snapshot of upcoming and active delivery dates.</p>
+  </header>
+  <section class="radiator" id="radiator"></section>
+  <section class="completed-wrapper" id="completed-wrapper" hidden>
+    <button class="toggle-completed" id="toggle-completed" type="button" aria-expanded="false">
+      Show completed milestones
+    </button>
+    <div class="radiator" id="completed-radiator" hidden></div>
+  </section>
+
+  <template id="milestone-template">
+    <article class="milestone-card">
+      <div class="milestone-head">
+        <h2 class="milestone-title"><a href="#" rel="noopener"></a></h2>
+        <div class="milestone-meta">
+          <span class="status"><span class="status-dot"></span><span class="status-label"></span></span>
+          <span class="badge category" hidden></span>
+        </div>
+      </div>
+      <div class="dates">
+        <span class="window"></span>
+        <span class="countdown"></span>
+      </div>
+      <div class="progress-bar"><span></span></div>
+    </article>
+  </template>
+
+  <script>
+    const milestones = [
+      { title: "Regional teams kick-off", url: "https://example.com/kickoff", start: "2024-05-28T09:00", category: "Launch" },
+      { title: "Prototype review", url: "https://example.com/prototype", start: "2024-06-10", end: "2024-06-14", category: "Design" },
+      { title: "MVP delivery", url: "https://example.com/mvp", start: "2024-07-01", end: "2024-07-05", category: "Product" },
+      { title: "Key user training", url: "https://example.com/training", start: "2024-07-12", category: "Adoption" }
+    ];
+
+    const MS = {
+      minute: 60 * 1000,
+      hour: 60 * 60 * 1000,
+      day: 24 * 60 * 60 * 1000
+    };
+
+    const radiator = document.getElementById('radiator');
+    const completedRadiator = document.getElementById('completed-radiator');
+    const completedWrapper = document.getElementById('completed-wrapper');
+    const toggleCompleted = document.getElementById('toggle-completed');
+    const template = document.getElementById('milestone-template');
+
+    function parseDate(value) {
+      const parsed = value instanceof Date ? value : new Date(value);
+      return isNaN(parsed.getTime()) ? null : parsed;
+    }
+
+    function normalizeMilestone(milestone, fallbackStart) {
+      const start = milestone.start ? parseDate(milestone.start) : new Date(fallbackStart);
+      const end = milestone.end ? parseDate(milestone.end) : null;
+      return { ...milestone, start, end };
+    }
+
+    function classifyMilestone({ start, end }, now) {
+      if (!start) return 'unknown';
+      const effectiveEnd = end || new Date(start.getTime() + MS.day);
+      if (now < start) return 'pending';
+      if (now > effectiveEnd) return 'done';
+      return 'active';
+    }
+
+    function formatWindow({ start, end }) {
+      if (!start) return 'Date to be confirmed';
+      const localeOpts = { day: '2-digit', month: 'short', year: 'numeric' };
+      const startStr = start.toLocaleString('en-US', localeOpts);
+      if (!end) {
+        return `\u25CF ${startStr}`;
+      }
+      const endStr = end.toLocaleString('en-US', localeOpts);
+      if (startStr === endStr) {
+        return `\u25CF ${startStr}`;
+      }
+      return `\u25CF ${startStr} – ${endStr}`;
+    }
+
+    function formatRelative(ms) {
+      const abs = Math.abs(ms);
+      const days = Math.floor(abs / MS.day);
+      if (days >= 1) {
+        const hours = Math.floor((abs % MS.day) / MS.hour);
+        return `${days} day${days !== 1 ? 's' : ''}${hours ? ` ${hours} h` : ''}`;
+      }
+      const hours = Math.floor(abs / MS.hour);
+      if (hours >= 1) {
+        const minutes = Math.floor((abs % MS.hour) / MS.minute);
+        return `${hours} h${minutes ? ` ${minutes} min` : ''}`;
+      }
+      const minutes = Math.max(1, Math.round(abs / MS.minute));
+      return `${minutes} min`;
+    }
+
+    function describeCountdown(milestone, now) {
+      const { start, end } = milestone;
+      if (!start) return 'Invalid date';
+      const effectiveEnd = end || new Date(start.getTime() + MS.day);
+      if (now < start) {
+        return `Starts in ${formatRelative(start - now)}`;
+      }
+      if (now <= effectiveEnd) {
+        return `Time remaining ${formatRelative(effectiveEnd - now)}`;
+      }
+      return `Finished ${formatRelative(now - effectiveEnd)} ago`;
+    }
+
+    function progressValue(milestone, now) {
+      const { start, end } = milestone;
+      if (!start) return 0;
+      if (now <= start) return 0;
+      const effectiveEnd = end || new Date(start.getTime() + MS.day);
+      if (now >= effectiveEnd) return 1;
+      return (now - start) / (effectiveEnd - start);
+    }
+
+    function statusLabel(status) {
+      switch (status) {
+        case 'pending': return 'Pending';
+        case 'active': return 'In progress';
+        case 'done': return 'Completed';
+        default: return 'No date';
+      }
+    }
+
+    function buildCategoryColors(items) {
+      const palette = [
+        '#33B990',
+        '#2A8C82',
+        '#F3C613',
+        '#0E5F5A',
+        '#9FD3C6',
+        '#2F7770',
+        '#C2E3DD'
+      ];
+      const unique = Array.from(new Set(items.filter(item => item.category).map(item => item.category)));
+      return unique.reduce((acc, category, index) => {
+        acc[category] = palette[index % palette.length];
+        return acc;
+      }, {});
+    }
+
+    function contrastColor(hex) {
+      if (!hex) return '#0F2D2E';
+      const value = hex.replace('#', '');
+      const bigint = parseInt(value, 16);
+      const r = (bigint >> 16) & 255;
+      const g = (bigint >> 8) & 255;
+      const b = bigint & 255;
+      const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+      return luminance > 0.6 ? '#0F2D2E' : '#FFFFFF';
+    }
+
+    function applyCategoryStyles(badge, category, colors) {
+      const color = colors[category];
+      if (!color) return;
+      badge.style.background = color;
+      badge.style.borderColor = color;
+      badge.style.color = contrastColor(color);
+    }
+
+    function render() {
+      const now = new Date();
+      radiator.innerHTML = '';
+      completedRadiator.innerHTML = '';
+      const items = milestones
+        .map((milestone) => normalizeMilestone(milestone, now))
+        .sort((a, b) => (a.start || 0) - (b.start || 0));
+
+      const categoryColors = buildCategoryColors(items);
+
+      items.forEach((item) => {
+        const node = template.content.firstElementChild.cloneNode(true);
+        const status = classifyMilestone(item, now);
+        node.classList.add(status);
+        const titleLink = node.querySelector('.milestone-title a');
+        titleLink.textContent = item.title || 'Untitled milestone';
+        if (item.url) {
+          titleLink.href = item.url;
+          titleLink.target = '_blank';
+        } else {
+          titleLink.href = '#';
+          titleLink.removeAttribute('target');
+        }
+        node.querySelector('.status-label').textContent = statusLabel(status);
+        node.querySelector('.countdown').textContent = describeCountdown(item, now);
+        node.querySelector('.window').textContent = formatWindow(item);
+        const progress = status === 'unknown' ? 0 : progressValue(item, now);
+        node.querySelector('.progress-bar span').style.setProperty('--w', `${Math.round(progress * 100)}%`);
+
+        const badge = node.querySelector('.category');
+        if (item.category) {
+          badge.textContent = item.category;
+          badge.hidden = false;
+          applyCategoryStyles(badge, item.category, categoryColors);
+        } else {
+          badge.hidden = true;
+        }
+        if (status === 'done') {
+          completedRadiator.appendChild(node);
+        } else {
+          radiator.appendChild(node);
+        }
+      });
+
+      const hasCompleted = completedRadiator.childElementCount > 0;
+      completedWrapper.hidden = !hasCompleted;
+      if (!hasCompleted) {
+        toggleCompleted.setAttribute('aria-expanded', 'false');
+        toggleCompleted.textContent = 'Show completed milestones';
+        completedRadiator.hidden = true;
+      } else {
+        const isOpen = completedRadiator.hidden === false;
+        toggleCompleted.setAttribute('aria-expanded', String(isOpen));
+        toggleCompleted.textContent = isOpen ? 'Hide completed milestones' : 'Show completed milestones';
+      }
+    }
+
+    render();
+    setInterval(render, MS.minute);
+
+    toggleCompleted?.addEventListener('click', () => {
+      const isOpen = completedRadiator.hidden === false;
+      completedRadiator.hidden = isOpen;
+      toggleCompleted.setAttribute('aria-expanded', String(!isOpen));
+      toggleCompleted.textContent = isOpen ? 'Show completed milestones' : 'Hide completed milestones';
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- translate radiator copy to English and document how to configure milestone titles, URLs, and default start dates
- add automatic category color coding, clickable milestone titles, and dynamic countdown messaging in English
- separate completed milestones behind a collapsible section while keeping pending/active items visible and refreshing counts each minute

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ca999f0adc832e9d9a250ff51a4561