### PR TITLE
feat: add alternative milestone countdown visualizations

### DIFF
--- a/milestones-radiator-grid.html
+++ b/milestones-radiator-grid.html
@@ -1,0 +1,317 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <!--
+    FlowingData-style Milestones Radiator (Time Blocks Edition)
+    -----------------------------------------------------------
+    1. Edit the `milestones` array in the <script> section to update dates or labels.
+    2. Paste this file's raw HTML into an Azure DevOps Wiki page to share the countdown grid.
+  -->
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Milestones Countdown Blocks</title>
+  <style>
+    :root {
+      --teal-100:#EAF6F4;
+      --teal-150:#D7ECE8;
+      --teal-200:#C2E3DD;
+      --teal-300:#9FD3C6;
+      --teal-600:#2A8C82;
+      --teal-700:#18786F;
+      --green-500:#33B990;
+      --gold-500:#F3C613;
+      --bg:#EAF6F4;
+      --panel:#FFFFFF;
+      --panel-soft:#F6FBFA;
+      --ink:#0F2D2E;
+      --muted:#5D7A7F;
+      --ring:#CFE0DC;
+      --shadow-elev:0 1px 2px rgba(6,44,40,.06),0 10px 24px rgba(6,44,40,.06);
+      --accent:#33B990;
+      --accent-2:#2A8C82;
+      --accent-3:#F3C613;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font: 14px/1.45 system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,"Helvetica Neue",Arial,"Noto Sans";
+      background: var(--bg);
+      color: var(--ink);
+      padding: 32px 24px 64px;
+    }
+    h1 {
+      font-size: 28px;
+      margin: 0 0 4px;
+      color: var(--teal-700);
+    }
+    p.lead { margin: 0 0 24px; color: var(--muted); }
+    .radiator {
+      display: grid;
+      gap: 20px;
+    }
+    @media (min-width: 720px) {
+      .radiator {
+        grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+      }
+    }
+    .milestone-card {
+      background: var(--panel);
+      border-radius: 16px;
+      border: 1px solid var(--ring);
+      padding: 24px;
+      box-shadow: var(--shadow-elev);
+      display: grid;
+      gap: 18px;
+      transition: transform .2s ease, box-shadow .2s ease;
+    }
+    .milestone-card:hover { transform: translateY(-2px); box-shadow: 0 18px 32px rgba(10,67,63,.12); }
+    .milestone-title { font-size: 18px; font-weight: 600; margin: 0; color: var(--teal-700); }
+    .milestone-title a { color: inherit; text-decoration: none; }
+    .milestone-title a:hover { text-decoration: underline; }
+    .meta { display: flex; flex-wrap: wrap; gap: 10px; font-size: 12px; color: var(--muted); }
+    .badge {
+      padding: 2px 10px;
+      border-radius: 999px;
+      border: 1px solid var(--ring);
+      background: var(--panel-soft);
+      text-transform: uppercase;
+      letter-spacing: .02em;
+      font-weight: 600;
+      font-size: 11px;
+    }
+    .grid-wrapper { display: grid; gap: 8px; }
+    .grid-header { display: flex; justify-content: space-between; font-size: 13px; color: var(--muted); }
+    .days-left { font-size: 22px; font-weight: 600; color: var(--teal-700); }
+    .tile-grid {
+      position: relative;
+      display: grid;
+      grid-template-columns: repeat(10, minmax(0, 1fr));
+      gap: 4px;
+    }
+    .tile {
+      position: relative;
+      display: block;
+      width: 100%;
+      padding-top: 100%;
+      border-radius: 6px;
+      background: var(--panel-soft);
+      border: 1px solid var(--ring);
+      box-shadow: inset 0 1px 1px rgba(15,45,46,.06);
+      transition: background .3s ease, border-color .3s ease;
+    }
+    .tile.active { background: linear-gradient(135deg, var(--accent), var(--accent-2)); border-color: transparent; }
+    .tile.past { opacity: .25; }
+    .overflow {
+      position: absolute;
+      inset: 0;
+      display: grid;
+      place-items: center;
+      font-size: 12px;
+      font-weight: 600;
+      color: var(--panel);
+      background: rgba(15,45,46,.55);
+      border-radius: inherit;
+      pointer-events: none;
+    }
+    .countdown { font-size: 15px; font-weight: 600; color: var(--ink); }
+    .window { font-size: 13px; color: var(--muted); }
+    .status { display: inline-flex; align-items: center; gap: 6px; font-weight: 600; font-size: 12px; letter-spacing: .02em; }
+    .status-dot { width: 8px; height: 8px; border-radius: 999px; background: currentColor; }
+    .milestone-card.pending .tile.active { background: linear-gradient(135deg, var(--gold-500), #FFDD55); }
+    .milestone-card.done .tile.active { background: linear-gradient(135deg, var(--teal-200), var(--teal-150)); }
+    .milestone-card.done .countdown { color: var(--muted); }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Milestones Countdown Blocks</h1>
+    <p class="lead">Visualiza cada día que falta con un mosaico estilo FlowingData: cada cuadrado es un día restante.</p>
+  </header>
+  <section class="radiator" id="radiator"></section>
+
+  <template id="milestone-template">
+    <article class="milestone-card">
+      <div>
+        <h2 class="milestone-title"><a href="#" rel="noopener"></a></h2>
+        <div class="meta">
+          <span class="status"><span class="status-dot"></span><span class="status-label"></span></span>
+          <span class="badge category" hidden></span>
+        </div>
+      </div>
+      <div class="grid-wrapper">
+        <div class="grid-header">
+          <span class="countdown"></span>
+          <span class="days-left"></span>
+        </div>
+        <div class="tile-grid"></div>
+        <div class="window"></div>
+      </div>
+    </article>
+  </template>
+
+  <script>
+    const milestones = [
+      { title: "MVP 1", url: "https://example.com/kickoff", end: "2025-10-17", category: "MVP" },
+      { title: "MVP 2", url: "https://example.com/prototype", end: "2025-11-14", category: "MVP" },
+      { title: "Release Sprint", url: "https://example.com/mvp", start: "2025-11-17", end: "2025-11-28", category: "Release" },
+      { title: "Pillar 2 Rating CR", url: "https://example.com/training", end: "2025-12-05", category: "CR" }
+    ];
+
+    const MS = {
+      minute: 60 * 1000,
+      hour: 60 * 60 * 1000,
+      day: 24 * 60 * 60 * 1000
+    };
+
+    const TOTAL_TILES = 30;
+
+    const template = document.getElementById('milestone-template');
+    const container = document.getElementById('radiator');
+
+    function parseDate(value) {
+      const parsed = value instanceof Date ? value : new Date(value);
+      return isNaN(parsed.getTime()) ? null : parsed;
+    }
+
+    function normalizeMilestone(milestone, now) {
+      const parsedStart = milestone.start ? parseDate(milestone.start) : null;
+      const hasExplicitStart = Boolean(parsedStart);
+      const start = parsedStart || new Date(now);
+      const end = milestone.end ? parseDate(milestone.end) : null;
+      return { ...milestone, start, end, hasExplicitStart };
+    }
+
+    function formatRelative(ms) {
+      const abs = Math.abs(ms);
+      const days = Math.floor(abs / MS.day);
+      if (days >= 1) {
+        const hours = Math.floor((abs % MS.day) / MS.hour);
+        return `${days} day${days !== 1 ? 's' : ''}${hours ? ` ${hours} h` : ''}`;
+      }
+      const hours = Math.floor(abs / MS.hour);
+      if (hours >= 1) {
+        const minutes = Math.floor((abs % MS.hour) / MS.minute);
+        return `${hours} h${minutes ? ` ${minutes} min` : ''}`;
+      }
+      const minutes = Math.max(1, Math.round(abs / MS.minute));
+      return `${minutes} min`;
+    }
+
+    function describeCountdown({ start, end, hasExplicitStart }, now) {
+      if (!hasExplicitStart && !end) return 'Invalid date';
+      const effectiveStart = hasExplicitStart ? start : now;
+      const effectiveEnd = end || new Date(effectiveStart.getTime() + MS.day);
+      if (now < effectiveStart) {
+        return `Begins in ${formatRelative(effectiveStart - now)}`;
+      }
+      if (now <= effectiveEnd) {
+        return `Ends in ${formatRelative(effectiveEnd - now)}`;
+      }
+      return `Finished ${formatRelative(now - effectiveEnd)} ago`;
+    }
+
+    function formatWindow({ start, end, hasExplicitStart }) {
+      if (!hasExplicitStart && !end) return 'Date to be confirmed';
+      const localeOpts = { day: '2-digit', month: 'short', year: 'numeric' };
+      if (!hasExplicitStart && end) {
+        return `\u25CF Until ${end.toLocaleString('en-US', localeOpts)}`;
+      }
+      if (!end) {
+        return `\u25CF ${start.toLocaleString('en-US', localeOpts)}`;
+      }
+      const startStr = start.toLocaleString('en-US', localeOpts);
+      const endStr = end.toLocaleString('en-US', localeOpts);
+      if (startStr === endStr) return `\u25CF ${startStr}`;
+      return `\u25CF ${startStr} – ${endStr}`;
+    }
+
+    function classifyMilestone({ start, end, hasExplicitStart }, now) {
+      if (!hasExplicitStart && !end) return 'unknown';
+      const effectiveStart = hasExplicitStart ? start : now;
+      const effectiveEnd = end || new Date(effectiveStart.getTime() + MS.day);
+      if (now < effectiveStart) return 'pending';
+      if (now > effectiveEnd) return 'done';
+      return 'active';
+    }
+
+    function daysRemaining({ start, end, hasExplicitStart }, now) {
+      if (!hasExplicitStart && !end) return 0;
+      const effectiveStart = hasExplicitStart ? start : now;
+      const effectiveEnd = end || new Date(effectiveStart.getTime() + MS.day);
+      if (now >= effectiveEnd) return 0;
+      const remainingMs = effectiveEnd - now;
+      return Math.max(0, Math.ceil(remainingMs / MS.day));
+    }
+
+    function buildTiles(grid, remaining) {
+      grid.innerHTML = '';
+      for (let i = 0; i < TOTAL_TILES; i += 1) {
+        const cell = document.createElement('span');
+        cell.className = 'tile';
+        if (i < remaining) {
+          cell.classList.add('active');
+        } else {
+          cell.classList.add('past');
+        }
+        grid.appendChild(cell);
+      }
+      if (remaining > TOTAL_TILES) {
+        const overlay = document.createElement('span');
+        overlay.className = 'overflow';
+        overlay.textContent = `+${remaining - TOTAL_TILES}`;
+        grid.appendChild(overlay);
+      }
+    }
+
+    function statusLabel(status) {
+      switch (status) {
+        case 'pending': return 'Pending';
+        case 'active': return 'In progress';
+        case 'done': return 'Completed';
+        default: return 'No date';
+      }
+    }
+
+    function render() {
+      const now = new Date();
+      container.innerHTML = '';
+      milestones
+        .map((milestone) => normalizeMilestone(milestone, now))
+        .sort((a, b) => (a.end || a.start) - (b.end || b.start))
+        .forEach((item) => {
+          const node = template.content.firstElementChild.cloneNode(true);
+          const status = classifyMilestone(item, now);
+          node.classList.add(status);
+          const titleLink = node.querySelector('.milestone-title a');
+          titleLink.textContent = item.title;
+          if (item.url) {
+            titleLink.href = item.url;
+            titleLink.target = '_blank';
+          } else {
+            titleLink.href = '#';
+          }
+
+          node.querySelector('.status-label').textContent = statusLabel(status);
+          node.querySelector('.countdown').textContent = describeCountdown(item, now);
+          node.querySelector('.window').textContent = formatWindow(item);
+
+          const remaining = daysRemaining(item, now);
+          node.querySelector('.days-left').textContent = remaining ? `${remaining} day${remaining !== 1 ? 's' : ''} left` : '0 days left';
+
+          buildTiles(node.querySelector('.tile-grid'), remaining);
+
+          const badge = node.querySelector('.category');
+          if (item.category) {
+            badge.hidden = false;
+            badge.textContent = item.category;
+          }
+
+          container.appendChild(node);
+        });
+    }
+
+    render();
+    setInterval(render, MS.minute);
+  </script>
+</body>
+</html>

--- a/milestones-radiator-radial.html
+++ b/milestones-radiator-radial.html
@@ -10,6 +10,7 @@
          - start (optional ISO date or date-time)
          - end (optional ISO date or date-time)
          - category (optional label for grouping)
+       Omit "start" to fall back to `ProjectStartDate` (defined below).
     2. Copy the whole HTML and paste it into an Azure DevOps Wiki page to publish the radiator.
   -->
   <meta charset="UTF-8" />
@@ -155,6 +156,8 @@
       { title: "Pillar 2 Rating CR", url: "https://example.com/training", end: "2025-12-05", category: "CR" }
     ];
 
+    const ProjectStartDate = new Date('2025-07-14T00:00:00');
+
     const MS = {
       minute: 60 * 1000,
       hour: 60 * 60 * 1000,
@@ -169,10 +172,10 @@
       return isNaN(parsed.getTime()) ? null : parsed;
     }
 
-    function normalizeMilestone(milestone, now) {
+    function normalizeMilestone(milestone) {
       const parsedStart = milestone.start ? parseDate(milestone.start) : null;
       const hasExplicitStart = Boolean(parsedStart);
-      const start = parsedStart || new Date(now);
+      const start = parsedStart ? new Date(parsedStart) : new Date(ProjectStartDate);
       const end = milestone.end ? parseDate(milestone.end) : null;
       return { ...milestone, start, end, hasExplicitStart };
     }
@@ -195,8 +198,14 @@
 
     function describeCountdown({ start, end, hasExplicitStart }, now) {
       if (!hasExplicitStart && !end) return 'Invalid date';
-      const effectiveStart = hasExplicitStart ? start : now;
+      const effectiveStart = hasExplicitStart ? start : ProjectStartDate;
       const effectiveEnd = end || new Date(effectiveStart.getTime() + MS.day);
+      if (!hasExplicitStart) {
+        if (now <= effectiveEnd) {
+          return `Ends in ${formatRelative(effectiveEnd - now)}`;
+        }
+        return `Finished ${formatRelative(now - effectiveEnd)} ago`;
+      }
       if (now < effectiveStart) {
         return `Begins in ${formatRelative(effectiveStart - now)}`;
       }
@@ -221,15 +230,17 @@
       return `\u25CF ${startStr} – ${endStr}`;
     }
 
-    function remainingRatio({ start, end, hasExplicitStart }, now) {
+    function completionRatio({ start, end, hasExplicitStart }, now) {
       if (!hasExplicitStart && !end) return 0;
-      const effectiveStart = hasExplicitStart ? start : now;
+      const effectiveStart = hasExplicitStart ? start : ProjectStartDate;
       const effectiveEnd = end || new Date(effectiveStart.getTime() + MS.day);
-      if (now >= effectiveEnd) return 0;
-      if (now <= effectiveStart) return 1;
+      if (now >= effectiveEnd) return 1;
       const total = Math.max(effectiveEnd - effectiveStart, MS.minute);
-      const remaining = Math.max(0, effectiveEnd - now);
-      return Math.min(1, remaining / total);
+      if (now <= effectiveStart) {
+        return 0;
+      }
+      const elapsed = Math.max(0, Math.min(total, now - effectiveStart));
+      return Math.min(1, elapsed / total);
     }
 
     function statusLabel(status) {
@@ -243,9 +254,11 @@
 
     function classifyMilestone({ start, end, hasExplicitStart }, now) {
       if (!hasExplicitStart && !end) return 'unknown';
-      const effectiveStart = hasExplicitStart ? start : now;
+      const effectiveStart = hasExplicitStart ? start : ProjectStartDate;
       const effectiveEnd = end || new Date(effectiveStart.getTime() + MS.day);
-      if (now < effectiveStart) return 'pending';
+      if (now < effectiveStart) {
+        return hasExplicitStart ? 'pending' : 'active';
+      }
       if (now > effectiveEnd) return 'done';
       return 'active';
     }
@@ -254,7 +267,7 @@
       const now = new Date();
       container.innerHTML = '';
       milestones
-        .map((milestone) => normalizeMilestone(milestone, now))
+        .map((milestone) => normalizeMilestone(milestone))
         .sort((a, b) => (a.end || a.start) - (b.end || b.start))
         .forEach((item) => {
           const node = template.content.firstElementChild.cloneNode(true);
@@ -273,7 +286,7 @@
           node.querySelector('.countdown').textContent = describeCountdown(item, now);
           node.querySelector('.window').textContent = formatWindow(item);
 
-          const ratio = remainingRatio(item, now);
+          const ratio = completionRatio(item, now);
           const meter = node.querySelector('.radial-meter');
           meter.style.setProperty('--p', (ratio * 100).toFixed(2));
           meter.dataset.label = `${Math.round(ratio * 100)}%`;

--- a/milestones-radiator-radial.html
+++ b/milestones-radiator-radial.html
@@ -234,13 +234,13 @@
       if (!hasExplicitStart && !end) return 0;
       const effectiveStart = hasExplicitStart ? start : ProjectStartDate;
       const effectiveEnd = end || new Date(effectiveStart.getTime() + MS.day);
-      if (now >= effectiveEnd) return 1;
+      if (now >= effectiveEnd) return 0;
       const total = Math.max(effectiveEnd - effectiveStart, MS.minute);
       if (now <= effectiveStart) {
-        return 0;
+        return 1;
       }
-      const elapsed = Math.max(0, Math.min(total, now - effectiveStart));
-      return Math.min(1, elapsed / total);
+      const remaining = Math.max(0, Math.min(total, effectiveEnd - now));
+      return Math.min(1, remaining / total);
     }
 
     function statusLabel(status) {

--- a/milestones-radiator-radial.html
+++ b/milestones-radiator-radial.html
@@ -1,0 +1,295 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <!--
+    FlowingData-style Milestones Radiator (Radial Countdown Edition)
+    ----------------------------------------------------------------
+    1. Update the `milestones` array in the <script> block below. Each object accepts:
+         - title (required, shown as the card title)
+         - url (optional link for more context)
+         - start (optional ISO date or date-time)
+         - end (optional ISO date or date-time)
+         - category (optional label for grouping)
+    2. Copy the whole HTML and paste it into an Azure DevOps Wiki page to publish the radiator.
+  -->
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Milestones Radial Countdown</title>
+  <style>
+    :root {
+      --teal-100:#EAF6F4;
+      --teal-150:#D7ECE8;
+      --teal-200:#C2E3DD;
+      --teal-300:#9FD3C6;
+      --teal-600:#2A8C82;
+      --teal-700:#18786F;
+      --green-500:#33B990;
+      --gold-500:#F3C613;
+      --bg:#EAF6F4;
+      --panel:#FFFFFF;
+      --panel-soft:#F6FBFA;
+      --ink:#0F2D2E;
+      --muted:#5D7A7F;
+      --ring:#CFE0DC;
+      --shadow-elev:0 1px 2px rgba(6,44,40,.06),0 10px 24px rgba(6,44,40,.06);
+      --accent:#33B990;
+      --accent-2:#2A8C82;
+      --accent-3:#F3C613;
+      --accent-4:#0E5F5A;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font: 14px/1.45 system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,"Helvetica Neue",Arial,"Noto Sans";
+      background: var(--bg);
+      color: var(--ink);
+      padding: 32px 24px 64px;
+    }
+    h1 {
+      font-size: 28px;
+      margin: 0 0 4px;
+      color: var(--teal-700);
+    }
+    p.lead { margin: 0 0 24px; color: var(--muted); }
+    .radiator {
+      display: grid;
+      gap: 20px;
+    }
+    @media (min-width: 720px) {
+      .radiator {
+        grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      }
+    }
+    .milestone-card {
+      background: var(--panel);
+      border-radius: 16px;
+      border: 1px solid var(--ring);
+      padding: 24px;
+      box-shadow: var(--shadow-elev);
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
+      transition: transform .2s ease, box-shadow .2s ease;
+    }
+    .milestone-card:hover { transform: translateY(-2px); box-shadow: 0 18px 32px rgba(10,67,63,.12); }
+    .milestone-title { font-size: 18px; font-weight: 600; margin: 0; color: var(--teal-700); }
+    .milestone-title a { color: inherit; text-decoration: none; }
+    .milestone-title a:hover { text-decoration: underline; }
+    .meta { display: flex; gap: 10px; align-items: center; flex-wrap: wrap; font-size: 12px; color: var(--muted); }
+    .badge {
+      padding: 2px 10px;
+      border-radius: 999px;
+      border: 1px solid var(--ring);
+      background: var(--panel-soft);
+      text-transform: uppercase;
+      letter-spacing: .02em;
+      font-weight: 600;
+      font-size: 11px;
+    }
+    .radial-wrapper {
+      display: grid;
+      grid-template-columns: auto 1fr;
+      gap: 20px;
+      align-items: center;
+    }
+    .radial-meter {
+      position: relative;
+      width: 140px;
+      aspect-ratio: 1;
+      border-radius: 50%;
+      display: grid;
+      place-items: center;
+      background:
+        radial-gradient(circle at center, var(--panel) 58%, transparent 59%),
+        conic-gradient(var(--accent) calc(var(--p, 0) * 1%), var(--panel-soft) 0);
+      border: 1px solid var(--ring);
+      box-shadow: inset 0 1px 2px rgba(15,45,46,.08);
+    }
+    .radial-meter::after {
+      content: attr(data-label);
+      font-size: 26px;
+      font-weight: 600;
+      color: var(--teal-700);
+    }
+    .countdown { font-size: 15px; font-weight: 600; color: var(--ink); }
+    .window { font-size: 13px; color: var(--muted); }
+    .status { display: inline-flex; align-items: center; gap: 6px; font-weight: 600; font-size: 12px; letter-spacing: .02em; }
+    .status-dot { width: 8px; height: 8px; border-radius: 999px; background: currentColor; }
+    .milestone-card.pending .radial-meter { --accent: var(--accent-3); }
+    .milestone-card.active .radial-meter { --accent: var(--accent); }
+    .milestone-card.done .radial-meter { --accent: var(--teal-300); }
+    .milestone-card.done .countdown { color: var(--muted); }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Milestones Radial Countdown</h1>
+    <p class="lead">A circular snapshot of how much tiempo queda hasta que acabe cada entrega clave.</p>
+  </header>
+  <section class="radiator" id="radiator"></section>
+
+  <template id="milestone-template">
+    <article class="milestone-card">
+      <div>
+        <h2 class="milestone-title"><a href="#" rel="noopener"></a></h2>
+        <div class="meta">
+          <span class="status"><span class="status-dot"></span><span class="status-label"></span></span>
+          <span class="badge category" hidden></span>
+        </div>
+      </div>
+      <div class="radial-wrapper">
+        <div class="radial-meter" data-label="00%"></div>
+        <div class="details">
+          <div class="countdown"></div>
+          <div class="window"></div>
+        </div>
+      </div>
+    </article>
+  </template>
+
+  <script>
+    const milestones = [
+      { title: "MVP 1", url: "https://example.com/kickoff", end: "2025-10-17", category: "MVP" },
+      { title: "MVP 2", url: "https://example.com/prototype", end: "2025-11-14", category: "MVP" },
+      { title: "Release Sprint", url: "https://example.com/mvp", start: "2025-11-17", end: "2025-11-28", category: "Release" },
+      { title: "Pillar 2 Rating CR", url: "https://example.com/training", end: "2025-12-05", category: "CR" }
+    ];
+
+    const MS = {
+      minute: 60 * 1000,
+      hour: 60 * 60 * 1000,
+      day: 24 * 60 * 60 * 1000
+    };
+
+    const template = document.getElementById('milestone-template');
+    const container = document.getElementById('radiator');
+
+    function parseDate(value) {
+      const parsed = value instanceof Date ? value : new Date(value);
+      return isNaN(parsed.getTime()) ? null : parsed;
+    }
+
+    function normalizeMilestone(milestone, now) {
+      const parsedStart = milestone.start ? parseDate(milestone.start) : null;
+      const hasExplicitStart = Boolean(parsedStart);
+      const start = parsedStart || new Date(now);
+      const end = milestone.end ? parseDate(milestone.end) : null;
+      return { ...milestone, start, end, hasExplicitStart };
+    }
+
+    function formatRelative(ms) {
+      const abs = Math.abs(ms);
+      const days = Math.floor(abs / MS.day);
+      if (days >= 1) {
+        const hours = Math.floor((abs % MS.day) / MS.hour);
+        return `${days} day${days !== 1 ? 's' : ''}${hours ? ` ${hours} h` : ''}`;
+      }
+      const hours = Math.floor(abs / MS.hour);
+      if (hours >= 1) {
+        const minutes = Math.floor((abs % MS.hour) / MS.minute);
+        return `${hours} h${minutes ? ` ${minutes} min` : ''}`;
+      }
+      const minutes = Math.max(1, Math.round(abs / MS.minute));
+      return `${minutes} min`;
+    }
+
+    function describeCountdown({ start, end, hasExplicitStart }, now) {
+      if (!hasExplicitStart && !end) return 'Invalid date';
+      const effectiveStart = hasExplicitStart ? start : now;
+      const effectiveEnd = end || new Date(effectiveStart.getTime() + MS.day);
+      if (now < effectiveStart) {
+        return `Begins in ${formatRelative(effectiveStart - now)}`;
+      }
+      if (now <= effectiveEnd) {
+        return `Ends in ${formatRelative(effectiveEnd - now)}`;
+      }
+      return `Finished ${formatRelative(now - effectiveEnd)} ago`;
+    }
+
+    function formatWindow({ start, end, hasExplicitStart }) {
+      if (!hasExplicitStart && !end) return 'Date to be confirmed';
+      const localeOpts = { day: '2-digit', month: 'short', year: 'numeric' };
+      if (!hasExplicitStart && end) {
+        return `\u25CF Until ${end.toLocaleString('en-US', localeOpts)}`;
+      }
+      if (!end) {
+        return `\u25CF ${start.toLocaleString('en-US', localeOpts)}`;
+      }
+      const startStr = start.toLocaleString('en-US', localeOpts);
+      const endStr = end.toLocaleString('en-US', localeOpts);
+      if (startStr === endStr) return `\u25CF ${startStr}`;
+      return `\u25CF ${startStr} – ${endStr}`;
+    }
+
+    function remainingRatio({ start, end, hasExplicitStart }, now) {
+      if (!hasExplicitStart && !end) return 0;
+      const effectiveStart = hasExplicitStart ? start : now;
+      const effectiveEnd = end || new Date(effectiveStart.getTime() + MS.day);
+      if (now >= effectiveEnd) return 0;
+      if (now <= effectiveStart) return 1;
+      const total = Math.max(effectiveEnd - effectiveStart, MS.minute);
+      const remaining = Math.max(0, effectiveEnd - now);
+      return Math.min(1, remaining / total);
+    }
+
+    function statusLabel(status) {
+      switch (status) {
+        case 'pending': return 'Pending';
+        case 'active': return 'In progress';
+        case 'done': return 'Completed';
+        default: return 'No date';
+      }
+    }
+
+    function classifyMilestone({ start, end, hasExplicitStart }, now) {
+      if (!hasExplicitStart && !end) return 'unknown';
+      const effectiveStart = hasExplicitStart ? start : now;
+      const effectiveEnd = end || new Date(effectiveStart.getTime() + MS.day);
+      if (now < effectiveStart) return 'pending';
+      if (now > effectiveEnd) return 'done';
+      return 'active';
+    }
+
+    function render() {
+      const now = new Date();
+      container.innerHTML = '';
+      milestones
+        .map((milestone) => normalizeMilestone(milestone, now))
+        .sort((a, b) => (a.end || a.start) - (b.end || b.start))
+        .forEach((item) => {
+          const node = template.content.firstElementChild.cloneNode(true);
+          const status = classifyMilestone(item, now);
+          node.classList.add(status);
+          const titleLink = node.querySelector('.milestone-title a');
+          titleLink.textContent = item.title;
+          if (item.url) {
+            titleLink.href = item.url;
+            titleLink.target = '_blank';
+          } else {
+            titleLink.href = '#';
+          }
+
+          node.querySelector('.status-label').textContent = statusLabel(status);
+          node.querySelector('.countdown').textContent = describeCountdown(item, now);
+          node.querySelector('.window').textContent = formatWindow(item);
+
+          const ratio = remainingRatio(item, now);
+          const meter = node.querySelector('.radial-meter');
+          meter.style.setProperty('--p', (ratio * 100).toFixed(2));
+          meter.dataset.label = `${Math.round(ratio * 100)}%`;
+
+          const badge = node.querySelector('.category');
+          if (item.category) {
+            badge.hidden = false;
+            badge.textContent = item.category;
+          }
+
+          container.appendChild(node);
+        });
+    }
+
+    render();
+    setInterval(render, MS.minute);
+  </script>
+</body>
+</html>

--- a/milestones-radiator-rings.html
+++ b/milestones-radiator-rings.html
@@ -52,20 +52,20 @@
     p.lead { margin: 0 0 24px; color: var(--muted); }
     .categories-grid {
       display: grid;
-      gap: 20px;
+      gap: 24px;
     }
     @media (min-width: 960px) {
       .categories-grid {
-        grid-template-columns: repeat(auto-fit, minmax(340px, 1fr));
+        grid-template-columns: repeat(auto-fit, minmax(420px, 1fr));
       }
     }
     .category-card {
-      background: var(--panel);
+      background: var(--card-bg, var(--panel));
       border-radius: 18px;
-      border: 1px solid var(--ring);
-      padding: 24px;
+      border: 1px solid rgba(15,45,46,0.08);
+      padding: 28px;
       display: grid;
-      gap: 20px;
+      gap: 24px;
       box-shadow: var(--shadow-elev);
     }
     .category-head {
@@ -94,16 +94,23 @@
     }
     .category-body {
       display: grid;
-      gap: 18px;
+      gap: 24px;
+    }
+    @media (min-width: 720px) {
+      .category-body {
+        grid-template-columns: minmax(240px, 0.9fr) minmax(260px, 1.1fr);
+        align-items: start;
+      }
     }
     .rings-panel {
       display: grid;
-      gap: 12px;
+      gap: 14px;
       justify-items: center;
+      width: 100%;
     }
     .chart-shell {
       position: relative;
-      width: min(260px, 100%);
+      width: min(280px, 100%);
       aspect-ratio: 1;
       display: grid;
       place-items: center;
@@ -150,13 +157,31 @@
       margin: 0;
       padding: 0;
       display: grid;
-      gap: 14px;
+      gap: 18px;
     }
     .milestone-item {
       display: grid;
       grid-template-columns: auto 1fr auto;
-      gap: 12px;
+      column-gap: 12px;
+      row-gap: 8px;
       align-items: center;
+    }
+    .progress-bar {
+      position: relative;
+      grid-column: 1 / span 3;
+      height: 10px;
+      border-radius: 999px;
+      border: 1px solid rgba(15,45,46,0.08);
+      background: rgba(255,255,255,0.55);
+      overflow: hidden;
+    }
+    .progress-bar span {
+      position: absolute;
+      inset: 0;
+      width: var(--w, 0%);
+      border-radius: inherit;
+      background: var(--slider-color, linear-gradient(90deg, rgba(15,122,108,0.9), rgba(244,157,55,0.9)));
+      transition: width .6s cubic-bezier(.22,.61,.36,1);
     }
     .swatch {
       width: 14px;
@@ -194,6 +219,7 @@
       font-variant-numeric: tabular-nums;
       font-weight: 600;
       color: var(--teal-600);
+      justify-self: end;
     }
     time { font-variant-numeric: tabular-nums; }
   </style>
@@ -237,19 +263,28 @@
       return { ...milestone, start, end, hasExplicitStart };
     }
 
-    function buildCategoryColors(items) {
-      const palette = [
-        '#33B990',
-        '#2A8C82',
-        '#F3C613',
-        '#0E5F5A',
-        '#9FD3C6',
-        '#2F7770',
-        '#C2E3DD'
-      ];
+    const ringPalette = [
+      '#0F7A6C',
+      '#F49D37',
+      '#F45B69',
+      '#33658A',
+      '#7A77FF',
+      '#55DDE0'
+    ];
+
+    const pastelPalette = [
+      '#F2FBF8',
+      '#FFF6ED',
+      '#F4F3FF',
+      '#FFF5F8',
+      '#EEF5FF',
+      '#F9F7FF'
+    ];
+
+    function buildCategoryBackgrounds(items) {
       const unique = Array.from(new Set(items.map(item => item.category || 'Uncategorized')));
       return unique.reduce((acc, category, index) => {
-        acc[category] = palette[index % palette.length];
+        acc[category] = pastelPalette[index % pastelPalette.length];
         return acc;
       }, {});
     }
@@ -363,27 +398,11 @@
       return milestone.end ? milestone.end : new Date(start.getTime() + MS.day);
     }
 
-    function adjustLuminance(hex, lum = 0) {
-      let value = String(hex).replace(/[^0-9a-f]/gi, '');
-      if (value.length < 6) {
-        value = value[0] + value[0] + value[1] + value[1] + value[2] + value[2];
-      }
-      const clamp = (num) => Math.min(255, Math.max(0, num));
-      let result = '#';
-      for (let i = 0; i < 3; i += 1) {
-        const channel = parseInt(value.substr(i * 2, 2), 16);
-        const delta = lum < 0 ? channel * lum : (255 - channel) * lum;
-        const adjusted = clamp(channel + delta);
-        result += Math.round(adjusted).toString(16).padStart(2, '0');
-      }
-      return result;
-    }
-
-    function buildRingsChart(items, now, baseColor) {
-      const radiusBase = 44;
-      const ringSpacing = 18;
-      const strokeWidth = 16;
-      const size = 280;
+    function buildRingsChart(items, now) {
+      const radiusBase = 56;
+      const ringSpacing = 26;
+      const strokeWidth = 18;
+      const size = 320;
       const center = size / 2;
 
       const svg = document.createElementNS(SVG_NS, 'svg');
@@ -399,8 +418,8 @@
       const aggregateEnd = new Date(Math.max(...ranges.map(range => range.end.getTime())));
       const aggregateRatio = completionForRange(aggregateStart, aggregateEnd, now);
 
-      const ringColors = items.map((_, index) => adjustLuminance(baseColor, Math.min(0.45, index * 0.18)));
-      const aggregateColor = adjustLuminance(baseColor, -0.2);
+      const ringColors = items.map((_, index) => ringPalette[index % ringPalette.length]);
+      const aggregateColor = '#0F2D2E';
 
       function createCircle({ radius, stroke, ratio = null, opacity = 1 }) {
         const circle = document.createElementNS(SVG_NS, 'circle');
@@ -464,12 +483,12 @@
         categoriesContainer.innerHTML = '<p>No milestones configured.</p>';
         return;
       }
-      const categoryColors = buildCategoryColors(normalized);
+      const categoryBackgrounds = buildCategoryBackgrounds(normalized);
 
       groupByCategory(normalized).forEach(({ category, milestones: groupItems }) => {
-        const baseColor = categoryColors[category] || '#2A8C82';
         const card = document.createElement('article');
         card.className = 'category-card';
+        card.style.setProperty('--card-bg', categoryBackgrounds[category] || 'var(--panel)');
 
         const head = document.createElement('div');
         head.className = 'category-head';
@@ -488,7 +507,7 @@
 
         const ringsPanel = document.createElement('div');
         ringsPanel.className = 'rings-panel';
-        const { svg, aggregateRatio, aggregateStart, aggregateEnd, ringColors } = buildRingsChart(groupItems, now, baseColor);
+        const { svg, aggregateRatio, aggregateStart, aggregateEnd, ringColors } = buildRingsChart(groupItems, now);
         const chartShell = document.createElement('div');
         chartShell.className = 'chart-shell';
         chartShell.appendChild(svg);
@@ -561,6 +580,15 @@
           const ratio = completionRatio(item, now);
           percentLabel.textContent = `${Math.round(ratio * 100)}%`;
           li.appendChild(percentLabel);
+
+          const progress = document.createElement('div');
+          progress.className = 'progress-bar';
+          const progressFill = document.createElement('span');
+          progressFill.style.setProperty('--w', `${(ratio * 100).toFixed(1)}%`);
+          progressFill.style.setProperty('--slider-color', ringColors[index % ringColors.length]);
+          progress.appendChild(progressFill);
+          progress.setAttribute('aria-label', `${Math.round(ratio * 100)}% of the window consumed`);
+          li.appendChild(progress);
 
           list.appendChild(li);
         });

--- a/milestones-radiator-rings.html
+++ b/milestones-radiator-rings.html
@@ -120,29 +120,6 @@
       height: auto;
       display: block;
     }
-    .chart-center {
-      position: absolute;
-      display: grid;
-      place-items: center;
-      text-align: center;
-      gap: 4px;
-      width: clamp(120px, 42%, 150px);
-      height: clamp(120px, 42%, 150px);
-      border-radius: 50%;
-      background: rgba(255,255,255,0.92);
-      box-shadow: 0 6px 16px rgba(15,45,46,.12);
-    }
-    .chart-center .percent {
-      font-size: 28px;
-      font-weight: 700;
-      color: var(--aggregate-color, var(--teal-700));
-    }
-    .chart-center .label {
-      font-size: 12px;
-      text-transform: uppercase;
-      letter-spacing: .08em;
-      color: var(--muted);
-    }
     .overall-window,
     .overall-countdown {
       font-size: 13px;
@@ -524,18 +501,6 @@
         const chartShell = document.createElement('div');
         chartShell.className = 'chart-shell';
         chartShell.appendChild(svg);
-        const center = document.createElement('div');
-        center.className = 'chart-center';
-        center.style.setProperty('--aggregate-color', aggregateColor);
-        const percent = document.createElement('span');
-        percent.className = 'percent';
-        percent.textContent = `${Math.round(aggregateRatio * 100)}%`;
-        const label = document.createElement('span');
-        label.className = 'label';
-        label.textContent = 'Time consumed';
-        center.appendChild(percent);
-        center.appendChild(label);
-        chartShell.appendChild(center);
         ringsPanel.appendChild(chartShell);
 
         const overallWindow = document.createElement('div');
@@ -548,7 +513,7 @@
         ringsPanel.appendChild(overallCountdown);
         const overallLegend = document.createElement('div');
         overallLegend.className = 'overall-legend';
-        overallLegend.textContent = 'Overall time consumed';
+        overallLegend.textContent = 'Overall ring & slider cover all milestones below';
         overallLegend.style.setProperty('--aggregate-color', aggregateColor);
         ringsPanel.appendChild(overallLegend);
 
@@ -556,6 +521,51 @@
 
         const list = document.createElement('ul');
         list.className = 'milestone-list';
+        const overallItem = document.createElement('li');
+        overallItem.className = 'milestone-item overall-item';
+
+        const overallSwatch = document.createElement('span');
+        overallSwatch.className = 'swatch';
+        overallSwatch.style.setProperty('--swatch', aggregateColor);
+        overallItem.appendChild(overallSwatch);
+
+        const overallText = document.createElement('div');
+        overallText.className = 'legend-text';
+
+        const overallTitle = document.createElement('span');
+        overallTitle.className = 'legend-title';
+        const milestoneNames = groupItems.map(item => item.title).join(', ');
+        overallTitle.textContent = `Overall (${milestoneNames})`;
+        overallText.appendChild(overallTitle);
+
+        const overallWindowLine = document.createElement('span');
+        overallWindowLine.className = 'legend-window';
+        overallWindowLine.textContent = formatOverallWindow(aggregateStart, aggregateEnd);
+        overallText.appendChild(overallWindowLine);
+
+        const overallCountdownLine = document.createElement('span');
+        overallCountdownLine.className = 'legend-countdown';
+        overallCountdownLine.textContent = describeRange(aggregateStart, aggregateEnd, now);
+        overallText.appendChild(overallCountdownLine);
+
+        overallItem.appendChild(overallText);
+
+        const overallPercentLabel = document.createElement('span');
+        overallPercentLabel.className = 'legend-percent';
+        overallPercentLabel.style.setProperty('color', aggregateColor);
+        overallPercentLabel.textContent = `${Math.round(aggregateRatio * 100)}%`;
+        overallItem.appendChild(overallPercentLabel);
+
+        const overallProgress = document.createElement('div');
+        overallProgress.className = 'progress-bar';
+        overallProgress.setAttribute('aria-label', `${Math.round(aggregateRatio * 100)}% of the category window consumed`);
+        const overallProgressFill = document.createElement('span');
+        overallProgressFill.style.setProperty('--w', `${(aggregateRatio * 100).toFixed(1)}%`);
+        overallProgressFill.style.setProperty('--slider-color', aggregateColor);
+        overallProgress.appendChild(overallProgressFill);
+        overallItem.appendChild(overallProgress);
+
+        list.appendChild(overallItem);
         groupItems.forEach((item, index) => {
           const li = document.createElement('li');
           li.className = 'milestone-item';

--- a/milestones-radiator-rings.html
+++ b/milestones-radiator-rings.html
@@ -96,7 +96,7 @@
       display: grid;
       gap: 24px;
     }
-    @media (min-width: 720px) {
+    @media (min-width: 960px) {
       .category-body {
         grid-template-columns: minmax(240px, 0.9fr) minmax(260px, 1.1fr);
         align-items: start;
@@ -125,8 +125,9 @@
       display: grid;
       place-items: center;
       text-align: center;
-      gap: 2px;
-      padding: 16px;
+      gap: 4px;
+      width: clamp(120px, 42%, 150px);
+      height: clamp(120px, 42%, 150px);
       border-radius: 50%;
       background: rgba(255,255,255,0.92);
       box-shadow: 0 6px 16px rgba(15,45,46,.12);
@@ -134,7 +135,7 @@
     .chart-center .percent {
       font-size: 28px;
       font-weight: 700;
-      color: var(--teal-700);
+      color: var(--aggregate-color, var(--teal-700));
     }
     .chart-center .label {
       font-size: 12px;
@@ -151,6 +152,22 @@
     .overall-countdown {
       font-weight: 600;
       color: var(--ink);
+    }
+    .overall-legend {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      font-size: 12px;
+      color: var(--muted);
+      margin-top: 4px;
+    }
+    .overall-legend::before {
+      content: '';
+      width: 14px;
+      height: 14px;
+      border-radius: 4px;
+      box-shadow: inset 0 0 0 1px rgba(15,45,46,.18);
+      background: var(--aggregate-color, var(--accent));
     }
     .milestone-list {
       list-style: none;
@@ -293,8 +310,7 @@
       const abs = Math.abs(ms);
       const days = Math.floor(abs / MS.day);
       if (days >= 1) {
-        const hours = Math.floor((abs % MS.day) / MS.hour);
-        return `${days} day${days !== 1 ? 's' : ''}${hours ? ` ${hours} h` : ''}`;
+        return `${days} day${days !== 1 ? 's' : ''}`;
       }
       const hours = Math.floor(abs / MS.hour);
       if (hours >= 1) {
@@ -419,7 +435,7 @@
       const aggregateRatio = completionForRange(aggregateStart, aggregateEnd, now);
 
       const ringColors = items.map((_, index) => ringPalette[index % ringPalette.length]);
-      const aggregateColor = '#0F2D2E';
+      const aggregateColor = '#2C9B88';
 
       function createCircle({ radius, stroke, ratio = null, opacity = 1 }) {
         const circle = document.createElementNS(SVG_NS, 'circle');
@@ -456,7 +472,8 @@
         aggregateRatio,
         aggregateStart,
         aggregateEnd,
-        ringColors
+        ringColors,
+        aggregateColor
       };
     }
 
@@ -507,12 +524,13 @@
 
         const ringsPanel = document.createElement('div');
         ringsPanel.className = 'rings-panel';
-        const { svg, aggregateRatio, aggregateStart, aggregateEnd, ringColors } = buildRingsChart(groupItems, now);
+        const { svg, aggregateRatio, aggregateStart, aggregateEnd, ringColors, aggregateColor } = buildRingsChart(groupItems, now);
         const chartShell = document.createElement('div');
         chartShell.className = 'chart-shell';
         chartShell.appendChild(svg);
         const center = document.createElement('div');
         center.className = 'chart-center';
+        center.style.setProperty('--aggregate-color', aggregateColor);
         const percent = document.createElement('span');
         percent.className = 'percent';
         percent.textContent = `${Math.round(aggregateRatio * 100)}%`;
@@ -527,11 +545,16 @@
         const overallWindow = document.createElement('div');
         overallWindow.className = 'overall-window';
         overallWindow.textContent = formatOverallWindow(aggregateStart, aggregateEnd);
+        ringsPanel.appendChild(overallWindow);
         const overallCountdown = document.createElement('div');
         overallCountdown.className = 'overall-countdown';
         overallCountdown.textContent = describeRange(aggregateStart, aggregateEnd, now);
-        ringsPanel.appendChild(overallWindow);
         ringsPanel.appendChild(overallCountdown);
+        const overallLegend = document.createElement('div');
+        overallLegend.className = 'overall-legend';
+        overallLegend.textContent = 'Overall completion';
+        overallLegend.style.setProperty('--aggregate-color', aggregateColor);
+        ringsPanel.appendChild(overallLegend);
 
         body.appendChild(ringsPanel);
 
@@ -577,6 +600,7 @@
 
           const percentLabel = document.createElement('span');
           percentLabel.className = 'legend-percent';
+          percentLabel.style.setProperty('color', ringColors[index]);
           const ratio = completionRatio(item, now);
           percentLabel.textContent = `${Math.round(ratio * 100)}%`;
           li.appendChild(percentLabel);

--- a/milestones-radiator-rings.html
+++ b/milestones-radiator-rings.html
@@ -385,24 +385,20 @@
       if (!hasExplicitStart && !end) return 0;
       const effectiveStart = hasExplicitStart ? start : ProjectStartDate;
       const effectiveEnd = end || new Date(effectiveStart.getTime() + MS.day);
-      if (now >= effectiveEnd) return 0;
+      if (now <= effectiveStart) return 0;
+      if (now >= effectiveEnd) return 1;
       const total = Math.max(effectiveEnd - effectiveStart, MS.minute);
-      if (now <= effectiveStart) {
-        return 1;
-      }
-      const remaining = Math.max(0, Math.min(total, effectiveEnd - now));
-      return Math.min(1, remaining / total);
+      const elapsed = Math.max(0, Math.min(total, now - effectiveStart));
+      return Math.min(1, elapsed / total);
     }
 
     function completionForRange(start, end, now) {
       if (!start || !end) return 0;
-      if (now >= end) return 0;
+      if (now <= start) return 0;
+      if (now >= end) return 1;
       const total = Math.max(end - start, MS.minute);
-      if (now <= start) {
-        return 1;
-      }
-      const remaining = Math.max(0, Math.min(total, end - now));
-      return Math.min(1, remaining / total);
+      const elapsed = Math.max(0, Math.min(total, now - start));
+      return Math.min(1, elapsed / total);
     }
 
     function getEffectiveStart(milestone) {
@@ -536,7 +532,7 @@
         percent.textContent = `${Math.round(aggregateRatio * 100)}%`;
         const label = document.createElement('span');
         label.className = 'label';
-        label.textContent = 'Overall';
+        label.textContent = 'Time consumed';
         center.appendChild(percent);
         center.appendChild(label);
         chartShell.appendChild(center);
@@ -552,7 +548,7 @@
         ringsPanel.appendChild(overallCountdown);
         const overallLegend = document.createElement('div');
         overallLegend.className = 'overall-legend';
-        overallLegend.textContent = 'Overall time remaining';
+        overallLegend.textContent = 'Overall time consumed';
         overallLegend.style.setProperty('--aggregate-color', aggregateColor);
         ringsPanel.appendChild(overallLegend);
 
@@ -611,7 +607,7 @@
           progressFill.style.setProperty('--w', `${(ratio * 100).toFixed(1)}%`);
           progressFill.style.setProperty('--slider-color', ringColors[index % ringColors.length]);
           progress.appendChild(progressFill);
-          progress.setAttribute('aria-label', `${Math.round(ratio * 100)}% of the window remaining`);
+          progress.setAttribute('aria-label', `${Math.round(ratio * 100)}% of the window consumed`);
           li.appendChild(progress);
 
           list.appendChild(li);

--- a/milestones-radiator-rings.html
+++ b/milestones-radiator-rings.html
@@ -1,0 +1,578 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <!--
+    FlowingData-style Milestones Radiator (Concentric Rings Edition)
+    ----------------------------------------------------------------
+    1. Edit the `milestones` array in the <script> block below. Each object accepts:
+         - title (required, shown in the legend and tooltips)
+         - url (optional link with more context)
+         - start (optional ISO date or date-time string)
+         - end (optional ISO date or date-time string)
+         - category (optional label used to group rings)
+       Omit "start" to default the milestone to `ProjectStartDate` (defined below).
+    2. Copy the whole HTML file and paste it into an Azure DevOps Wiki page to publish
+       the visualization as-is.
+  -->
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Milestones Concentric Rings</title>
+  <style>
+    :root {
+      --teal-100:#EAF6F4;
+      --teal-150:#D7ECE8;
+      --teal-200:#C2E3DD;
+      --teal-300:#9FD3C6;
+      --teal-600:#2A8C82;
+      --teal-700:#18786F;
+      --green-500:#33B990;
+      --gold-500:#F3C613;
+      --bg:#EAF6F4;
+      --panel:#FFFFFF;
+      --panel-soft:#F6FBFA;
+      --ink:#0F2D2E;
+      --muted:#5D7A7F;
+      --ring:#CFE0DC;
+      --shadow-elev:0 1px 2px rgba(6,44,40,.06),0 12px 28px rgba(6,44,40,.08);
+      --accent:#33B990;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font: 14px/1.45 system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,"Helvetica Neue",Arial,"Noto Sans";
+      background: var(--bg);
+      color: var(--ink);
+      padding: 32px 24px 64px;
+    }
+    h1 {
+      font-size: 28px;
+      margin: 0 0 4px;
+      color: var(--teal-700);
+    }
+    p.lead { margin: 0 0 24px; color: var(--muted); }
+    .categories-grid {
+      display: grid;
+      gap: 20px;
+    }
+    @media (min-width: 960px) {
+      .categories-grid {
+        grid-template-columns: repeat(auto-fit, minmax(340px, 1fr));
+      }
+    }
+    .category-card {
+      background: var(--panel);
+      border-radius: 18px;
+      border: 1px solid var(--ring);
+      padding: 24px;
+      display: grid;
+      gap: 20px;
+      box-shadow: var(--shadow-elev);
+    }
+    .category-head {
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: space-between;
+      gap: 12px;
+      align-items: baseline;
+    }
+    .category-title {
+      font-size: 20px;
+      font-weight: 600;
+      color: var(--teal-700);
+      margin: 0;
+    }
+    .badge {
+      padding: 4px 12px;
+      border-radius: 999px;
+      border: 1px solid var(--ring);
+      background: var(--panel-soft);
+      font-size: 11px;
+      letter-spacing: .04em;
+      text-transform: uppercase;
+      font-weight: 600;
+      color: var(--muted);
+    }
+    .category-body {
+      display: grid;
+      gap: 18px;
+    }
+    .rings-panel {
+      display: grid;
+      gap: 12px;
+      justify-items: center;
+    }
+    .chart-shell {
+      position: relative;
+      width: min(260px, 100%);
+      aspect-ratio: 1;
+      display: grid;
+      place-items: center;
+    }
+    .rings-chart {
+      width: 100%;
+      height: auto;
+      display: block;
+    }
+    .chart-center {
+      position: absolute;
+      display: grid;
+      place-items: center;
+      text-align: center;
+      gap: 2px;
+      padding: 16px;
+      border-radius: 50%;
+      background: rgba(255,255,255,0.92);
+      box-shadow: 0 6px 16px rgba(15,45,46,.12);
+    }
+    .chart-center .percent {
+      font-size: 28px;
+      font-weight: 700;
+      color: var(--teal-700);
+    }
+    .chart-center .label {
+      font-size: 12px;
+      text-transform: uppercase;
+      letter-spacing: .08em;
+      color: var(--muted);
+    }
+    .overall-window,
+    .overall-countdown {
+      font-size: 13px;
+      color: var(--muted);
+      text-align: center;
+    }
+    .overall-countdown {
+      font-weight: 600;
+      color: var(--ink);
+    }
+    .milestone-list {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      display: grid;
+      gap: 14px;
+    }
+    .milestone-item {
+      display: grid;
+      grid-template-columns: auto 1fr auto;
+      gap: 12px;
+      align-items: center;
+    }
+    .swatch {
+      width: 14px;
+      height: 14px;
+      border-radius: 4px;
+      background: var(--swatch);
+      box-shadow: inset 0 0 0 1px rgba(15,45,46,.18);
+    }
+    .legend-text {
+      display: grid;
+      gap: 2px;
+    }
+    .legend-title {
+      font-weight: 600;
+      color: var(--teal-700);
+    }
+    .legend-title a {
+      color: inherit;
+      text-decoration: none;
+    }
+    .legend-title a:hover,
+    .legend-title a:focus {
+      text-decoration: underline;
+    }
+    .legend-window {
+      font-size: 12px;
+      color: var(--muted);
+    }
+    .legend-countdown {
+      font-size: 12px;
+      color: var(--ink);
+      font-weight: 600;
+    }
+    .legend-percent {
+      font-variant-numeric: tabular-nums;
+      font-weight: 600;
+      color: var(--teal-600);
+    }
+    time { font-variant-numeric: tabular-nums; }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Milestones Concentric Rings</h1>
+    <p class="lead">Visualiza cada categoría como anillos concéntricos que muestran cuánto tiempo se ha consumido hasta su próxima fecha clave.</p>
+  </header>
+  <section class="categories-grid" id="categories"></section>
+
+  <script>
+    const milestones = [
+      { title: "MVP 1", url: "https://example.com/kickoff", end: "2025-10-17", category: "MVP" },
+      { title: "MVP 2", url: "https://example.com/prototype", end: "2025-11-14", category: "MVP" },
+      { title: "Release Sprint", url: "https://example.com/mvp", start: "2025-11-17", end: "2025-11-28", category: "Release" },
+      { title: "Pillar 2 Rating CR", url: "https://example.com/training", end: "2025-12-05", category: "CR" }
+    ];
+
+    const ProjectStartDate = new Date('2025-07-14T00:00:00');
+
+    const MS = {
+      minute: 60 * 1000,
+      hour: 60 * 60 * 1000,
+      day: 24 * 60 * 60 * 1000
+    };
+
+    const categoriesContainer = document.getElementById('categories');
+    const SVG_NS = 'http://www.w3.org/2000/svg';
+
+    function parseDate(value) {
+      const parsed = value instanceof Date ? value : new Date(value);
+      return isNaN(parsed.getTime()) ? null : parsed;
+    }
+
+    function normalizeMilestone(milestone) {
+      const parsedStart = milestone.start ? parseDate(milestone.start) : null;
+      const hasExplicitStart = Boolean(parsedStart);
+      const start = parsedStart ? new Date(parsedStart) : new Date(ProjectStartDate);
+      const end = milestone.end ? parseDate(milestone.end) : null;
+      return { ...milestone, start, end, hasExplicitStart };
+    }
+
+    function buildCategoryColors(items) {
+      const palette = [
+        '#33B990',
+        '#2A8C82',
+        '#F3C613',
+        '#0E5F5A',
+        '#9FD3C6',
+        '#2F7770',
+        '#C2E3DD'
+      ];
+      const unique = Array.from(new Set(items.map(item => item.category || 'Uncategorized')));
+      return unique.reduce((acc, category, index) => {
+        acc[category] = palette[index % palette.length];
+        return acc;
+      }, {});
+    }
+
+    function formatRelative(ms) {
+      const abs = Math.abs(ms);
+      const days = Math.floor(abs / MS.day);
+      if (days >= 1) {
+        const hours = Math.floor((abs % MS.day) / MS.hour);
+        return `${days} day${days !== 1 ? 's' : ''}${hours ? ` ${hours} h` : ''}`;
+      }
+      const hours = Math.floor(abs / MS.hour);
+      if (hours >= 1) {
+        const minutes = Math.floor((abs % MS.hour) / MS.minute);
+        return `${hours} h${minutes ? ` ${minutes} min` : ''}`;
+      }
+      const minutes = Math.max(1, Math.round(abs / MS.minute));
+      return `${minutes} min`;
+    }
+
+    function formatWindow({ start, end, hasExplicitStart }) {
+      if (!hasExplicitStart && !end) return 'Date to be confirmed';
+      const localeOpts = { day: '2-digit', month: 'short', year: 'numeric' };
+      if (!hasExplicitStart && end) {
+        const endStr = end.toLocaleString('en-US', localeOpts);
+        return `\u25CF Until ${endStr}`;
+      }
+      const startStr = start.toLocaleString('en-US', localeOpts);
+      if (!end) {
+        return `\u25CF ${startStr}`;
+      }
+      const endStr = end.toLocaleString('en-US', localeOpts);
+      if (startStr === endStr) {
+        return `\u25CF ${startStr}`;
+      }
+      return `\u25CF ${startStr} – ${endStr}`;
+    }
+
+    function formatOverallWindow(start, end) {
+      const localeOpts = { day: '2-digit', month: 'short', year: 'numeric' };
+      const startStr = start.toLocaleString('en-US', localeOpts);
+      const endStr = end.toLocaleString('en-US', localeOpts);
+      if (startStr === endStr) {
+        return `\u25CF ${startStr}`;
+      }
+      return `\u25CF ${startStr} – ${endStr}`;
+    }
+
+    function describeCountdown(milestone, now) {
+      const { start, end, hasExplicitStart } = milestone;
+      if (!hasExplicitStart && !end) return 'Invalid date';
+      const effectiveStart = hasExplicitStart ? start : ProjectStartDate;
+      const effectiveEnd = end || new Date(effectiveStart.getTime() + MS.day);
+      if (!hasExplicitStart) {
+        if (now <= effectiveEnd) {
+          return `Ends in ${formatRelative(effectiveEnd - now)}`;
+        }
+        return `Finished ${formatRelative(now - effectiveEnd)} ago`;
+      }
+      if (now < effectiveStart) {
+        return `Begins in ${formatRelative(effectiveStart - now)}`;
+      }
+      if (now <= effectiveEnd) {
+        return `Ends in ${formatRelative(effectiveEnd - now)}`;
+      }
+      return `Finished ${formatRelative(now - effectiveEnd)} ago`;
+    }
+
+    function describeRange(start, end, now) {
+      if (!start || !end) return 'Date to be confirmed';
+      if (now < start) {
+        return `Begins in ${formatRelative(start - now)}`;
+      }
+      if (now <= end) {
+        return `Ends in ${formatRelative(end - now)}`;
+      }
+      return `Finished ${formatRelative(now - end)} ago`;
+    }
+
+    function completionRatio(milestone, now) {
+      const { start, end, hasExplicitStart } = milestone;
+      if (!hasExplicitStart && !end) return 0;
+      const effectiveStart = hasExplicitStart ? start : ProjectStartDate;
+      const effectiveEnd = end || new Date(effectiveStart.getTime() + MS.day);
+      if (now >= effectiveEnd) return 1;
+      const total = Math.max(effectiveEnd - effectiveStart, MS.minute);
+      if (now <= effectiveStart) {
+        return 0;
+      }
+      const elapsed = Math.max(0, Math.min(total, now - effectiveStart));
+      return Math.min(1, elapsed / total);
+    }
+
+    function completionForRange(start, end, now) {
+      if (!start || !end) return 0;
+      if (now >= end) return 1;
+      const total = Math.max(end - start, MS.minute);
+      if (now <= start) {
+        return 0;
+      }
+      const elapsed = Math.max(0, Math.min(total, now - start));
+      return Math.min(1, elapsed / total);
+    }
+
+    function getEffectiveStart(milestone) {
+      return milestone.hasExplicitStart ? milestone.start : new Date(ProjectStartDate);
+    }
+
+    function getEffectiveEnd(milestone) {
+      const start = getEffectiveStart(milestone);
+      return milestone.end ? milestone.end : new Date(start.getTime() + MS.day);
+    }
+
+    function adjustLuminance(hex, lum = 0) {
+      let value = String(hex).replace(/[^0-9a-f]/gi, '');
+      if (value.length < 6) {
+        value = value[0] + value[0] + value[1] + value[1] + value[2] + value[2];
+      }
+      const clamp = (num) => Math.min(255, Math.max(0, num));
+      let result = '#';
+      for (let i = 0; i < 3; i += 1) {
+        const channel = parseInt(value.substr(i * 2, 2), 16);
+        const delta = lum < 0 ? channel * lum : (255 - channel) * lum;
+        const adjusted = clamp(channel + delta);
+        result += Math.round(adjusted).toString(16).padStart(2, '0');
+      }
+      return result;
+    }
+
+    function buildRingsChart(items, now, baseColor) {
+      const radiusBase = 44;
+      const ringSpacing = 18;
+      const strokeWidth = 16;
+      const size = 280;
+      const center = size / 2;
+
+      const svg = document.createElementNS(SVG_NS, 'svg');
+      svg.setAttribute('viewBox', `0 0 ${size} ${size}`);
+      svg.setAttribute('class', 'rings-chart');
+
+      const ranges = items.map((item) => ({
+        start: getEffectiveStart(item),
+        end: getEffectiveEnd(item)
+      }));
+
+      const aggregateStart = new Date(Math.min(...ranges.map(range => range.start.getTime())));
+      const aggregateEnd = new Date(Math.max(...ranges.map(range => range.end.getTime())));
+      const aggregateRatio = completionForRange(aggregateStart, aggregateEnd, now);
+
+      const ringColors = items.map((_, index) => adjustLuminance(baseColor, Math.min(0.45, index * 0.18)));
+      const aggregateColor = adjustLuminance(baseColor, -0.2);
+
+      function createCircle({ radius, stroke, ratio = null, opacity = 1 }) {
+        const circle = document.createElementNS(SVG_NS, 'circle');
+        circle.setAttribute('cx', center);
+        circle.setAttribute('cy', center);
+        circle.setAttribute('r', radius);
+        circle.setAttribute('fill', 'none');
+        circle.setAttribute('stroke', stroke);
+        circle.setAttribute('stroke-width', strokeWidth);
+        circle.setAttribute('stroke-linecap', 'round');
+        circle.setAttribute('opacity', opacity);
+        circle.setAttribute('transform', `rotate(-90 ${center} ${center})`);
+        if (ratio !== null) {
+          const circumference = 2 * Math.PI * radius;
+          circle.setAttribute('stroke-dasharray', circumference.toFixed(3));
+          circle.setAttribute('stroke-dashoffset', ((1 - ratio) * circumference).toFixed(3));
+        }
+        return circle;
+      }
+
+      items.forEach((item, index) => {
+        const radius = radiusBase + index * ringSpacing;
+        svg.appendChild(createCircle({ radius, stroke: 'rgba(207, 224, 220, 0.6)', opacity: 1 }));
+        const ratio = completionRatio(item, now);
+        svg.appendChild(createCircle({ radius, stroke: ringColors[index], ratio }));
+      });
+
+      const aggregateRadius = radiusBase + items.length * ringSpacing;
+      svg.appendChild(createCircle({ radius: aggregateRadius, stroke: 'rgba(207, 224, 220, 0.6)', opacity: 1 }));
+      svg.appendChild(createCircle({ radius: aggregateRadius, stroke: aggregateColor, ratio: aggregateRatio }));
+
+      return {
+        svg,
+        aggregateRatio,
+        aggregateStart,
+        aggregateEnd,
+        ringColors
+      };
+    }
+
+    function groupByCategory(items) {
+      const map = new Map();
+      items.forEach((item) => {
+        const key = item.category || 'Uncategorized';
+        if (!map.has(key)) {
+          map.set(key, []);
+        }
+        map.get(key).push(item);
+      });
+      return Array.from(map.entries()).map(([category, list]) => ({
+        category,
+        milestones: list.sort((a, b) => (getEffectiveEnd(a) - getEffectiveEnd(b)))
+      }));
+    }
+
+    function render() {
+      const now = new Date();
+      categoriesContainer.innerHTML = '';
+      const normalized = milestones.map(normalizeMilestone);
+      if (!normalized.length) {
+        categoriesContainer.innerHTML = '<p>No milestones configured.</p>';
+        return;
+      }
+      const categoryColors = buildCategoryColors(normalized);
+
+      groupByCategory(normalized).forEach(({ category, milestones: groupItems }) => {
+        const baseColor = categoryColors[category] || '#2A8C82';
+        const card = document.createElement('article');
+        card.className = 'category-card';
+
+        const head = document.createElement('div');
+        head.className = 'category-head';
+        const title = document.createElement('h2');
+        title.className = 'category-title';
+        title.textContent = category;
+        const badge = document.createElement('span');
+        badge.className = 'badge';
+        badge.textContent = `${groupItems.length} milestone${groupItems.length !== 1 ? 's' : ''}`;
+        head.appendChild(title);
+        head.appendChild(badge);
+        card.appendChild(head);
+
+        const body = document.createElement('div');
+        body.className = 'category-body';
+
+        const ringsPanel = document.createElement('div');
+        ringsPanel.className = 'rings-panel';
+        const { svg, aggregateRatio, aggregateStart, aggregateEnd, ringColors } = buildRingsChart(groupItems, now, baseColor);
+        const chartShell = document.createElement('div');
+        chartShell.className = 'chart-shell';
+        chartShell.appendChild(svg);
+        const center = document.createElement('div');
+        center.className = 'chart-center';
+        const percent = document.createElement('span');
+        percent.className = 'percent';
+        percent.textContent = `${Math.round(aggregateRatio * 100)}%`;
+        const label = document.createElement('span');
+        label.className = 'label';
+        label.textContent = 'Overall';
+        center.appendChild(percent);
+        center.appendChild(label);
+        chartShell.appendChild(center);
+        ringsPanel.appendChild(chartShell);
+
+        const overallWindow = document.createElement('div');
+        overallWindow.className = 'overall-window';
+        overallWindow.textContent = formatOverallWindow(aggregateStart, aggregateEnd);
+        const overallCountdown = document.createElement('div');
+        overallCountdown.className = 'overall-countdown';
+        overallCountdown.textContent = describeRange(aggregateStart, aggregateEnd, now);
+        ringsPanel.appendChild(overallWindow);
+        ringsPanel.appendChild(overallCountdown);
+
+        body.appendChild(ringsPanel);
+
+        const list = document.createElement('ul');
+        list.className = 'milestone-list';
+        groupItems.forEach((item, index) => {
+          const li = document.createElement('li');
+          li.className = 'milestone-item';
+
+          const swatch = document.createElement('span');
+          swatch.className = 'swatch';
+          swatch.style.setProperty('--swatch', ringColors[index]);
+          li.appendChild(swatch);
+
+          const legendText = document.createElement('div');
+          legendText.className = 'legend-text';
+
+          const titleLine = document.createElement('span');
+          titleLine.className = 'legend-title';
+          if (item.url) {
+            const link = document.createElement('a');
+            link.href = item.url;
+            link.textContent = item.title;
+            link.target = '_blank';
+            link.rel = 'noopener';
+            titleLine.appendChild(link);
+          } else {
+            titleLine.textContent = item.title;
+          }
+          legendText.appendChild(titleLine);
+
+          const windowLine = document.createElement('span');
+          windowLine.className = 'legend-window';
+          windowLine.textContent = formatWindow(item);
+          legendText.appendChild(windowLine);
+
+          const countdownLine = document.createElement('span');
+          countdownLine.className = 'legend-countdown';
+          countdownLine.textContent = describeCountdown(item, now);
+          legendText.appendChild(countdownLine);
+
+          li.appendChild(legendText);
+
+          const percentLabel = document.createElement('span');
+          percentLabel.className = 'legend-percent';
+          const ratio = completionRatio(item, now);
+          percentLabel.textContent = `${Math.round(ratio * 100)}%`;
+          li.appendChild(percentLabel);
+
+          list.appendChild(li);
+        });
+
+        body.appendChild(list);
+        card.appendChild(body);
+        categoriesContainer.appendChild(card);
+      });
+    }
+
+    render();
+    setInterval(render, MS.minute);
+  </script>
+</body>
+</html>

--- a/milestones-radiator-rings.html
+++ b/milestones-radiator-rings.html
@@ -385,24 +385,24 @@
       if (!hasExplicitStart && !end) return 0;
       const effectiveStart = hasExplicitStart ? start : ProjectStartDate;
       const effectiveEnd = end || new Date(effectiveStart.getTime() + MS.day);
-      if (now >= effectiveEnd) return 1;
+      if (now >= effectiveEnd) return 0;
       const total = Math.max(effectiveEnd - effectiveStart, MS.minute);
       if (now <= effectiveStart) {
-        return 0;
+        return 1;
       }
-      const elapsed = Math.max(0, Math.min(total, now - effectiveStart));
-      return Math.min(1, elapsed / total);
+      const remaining = Math.max(0, Math.min(total, effectiveEnd - now));
+      return Math.min(1, remaining / total);
     }
 
     function completionForRange(start, end, now) {
       if (!start || !end) return 0;
-      if (now >= end) return 1;
+      if (now >= end) return 0;
       const total = Math.max(end - start, MS.minute);
       if (now <= start) {
-        return 0;
+        return 1;
       }
-      const elapsed = Math.max(0, Math.min(total, now - start));
-      return Math.min(1, elapsed / total);
+      const remaining = Math.max(0, Math.min(total, end - now));
+      return Math.min(1, remaining / total);
     }
 
     function getEffectiveStart(milestone) {
@@ -552,7 +552,7 @@
         ringsPanel.appendChild(overallCountdown);
         const overallLegend = document.createElement('div');
         overallLegend.className = 'overall-legend';
-        overallLegend.textContent = 'Overall completion';
+        overallLegend.textContent = 'Overall time remaining';
         overallLegend.style.setProperty('--aggregate-color', aggregateColor);
         ringsPanel.appendChild(overallLegend);
 
@@ -611,7 +611,7 @@
           progressFill.style.setProperty('--w', `${(ratio * 100).toFixed(1)}%`);
           progressFill.style.setProperty('--slider-color', ringColors[index % ringColors.length]);
           progress.appendChild(progressFill);
-          progress.setAttribute('aria-label', `${Math.round(ratio * 100)}% of the window consumed`);
+          progress.setAttribute('aria-label', `${Math.round(ratio * 100)}% of the window remaining`);
           li.appendChild(progress);
 
           list.appendChild(li);

--- a/milestones-radiator-rings.html
+++ b/milestones-radiator-rings.html
@@ -130,22 +130,6 @@
       font-weight: 600;
       color: var(--ink);
     }
-    .overall-legend {
-      display: inline-flex;
-      align-items: center;
-      gap: 8px;
-      font-size: 12px;
-      color: var(--muted);
-      margin-top: 4px;
-    }
-    .overall-legend::before {
-      content: '';
-      width: 14px;
-      height: 14px;
-      border-radius: 4px;
-      box-shadow: inset 0 0 0 1px rgba(15,45,46,.18);
-      background: var(--aggregate-color, var(--accent));
-    }
     .milestone-list {
       list-style: none;
       margin: 0;
@@ -258,12 +242,12 @@
     }
 
     const ringPalette = [
-      '#0F7A6C',
-      '#F49D37',
-      '#F45B69',
-      '#33658A',
-      '#7A77FF',
-      '#55DDE0'
+      '#1E88E5',
+      '#FB8C00',
+      '#8E24AA',
+      '#43A047',
+      '#F4511E',
+      '#00ACC1'
     ];
 
     const pastelPalette = [
@@ -403,12 +387,19 @@
         end: getEffectiveEnd(item)
       }));
 
-      const aggregateStart = new Date(Math.min(...ranges.map(range => range.start.getTime())));
-      const aggregateEnd = new Date(Math.max(...ranges.map(range => range.end.getTime())));
-      const aggregateRatio = completionForRange(aggregateStart, aggregateEnd, now);
+      const showAggregate = items.length > 1;
+      const aggregateStart = showAggregate
+        ? new Date(Math.min(...ranges.map(range => range.start.getTime())))
+        : null;
+      const aggregateEnd = showAggregate
+        ? new Date(Math.max(...ranges.map(range => range.end.getTime())))
+        : null;
+      const aggregateRatio = showAggregate && aggregateStart && aggregateEnd
+        ? completionForRange(aggregateStart, aggregateEnd, now)
+        : null;
 
       const ringColors = items.map((_, index) => ringPalette[index % ringPalette.length]);
-      const aggregateColor = '#2C9B88';
+      const aggregateColor = '#F9C80E';
 
       function createCircle({ radius, stroke, ratio = null, opacity = 1 }) {
         const circle = document.createElementNS(SVG_NS, 'circle');
@@ -436,17 +427,21 @@
         svg.appendChild(createCircle({ radius, stroke: ringColors[index], ratio }));
       });
 
-      const aggregateRadius = radiusBase + items.length * ringSpacing;
-      svg.appendChild(createCircle({ radius: aggregateRadius, stroke: 'rgba(207, 224, 220, 0.6)', opacity: 1 }));
-      svg.appendChild(createCircle({ radius: aggregateRadius, stroke: aggregateColor, ratio: aggregateRatio }));
+      if (showAggregate) {
+        const aggregateRadius = radiusBase + items.length * ringSpacing;
+        svg.appendChild(createCircle({ radius: aggregateRadius, stroke: 'rgba(207, 224, 220, 0.6)', opacity: 1 }));
+        svg.appendChild(createCircle({ radius: aggregateRadius, stroke: aggregateColor, ratio: aggregateRatio }));
+      }
 
       return {
         svg,
-        aggregateRatio,
-        aggregateStart,
-        aggregateEnd,
-        ringColors,
-        aggregateColor
+        aggregate: showAggregate ? {
+          ratio: aggregateRatio,
+          start: aggregateStart,
+          end: aggregateEnd,
+          color: aggregateColor
+        } : null,
+        ringColors
       };
     }
 
@@ -497,75 +492,74 @@
 
         const ringsPanel = document.createElement('div');
         ringsPanel.className = 'rings-panel';
-        const { svg, aggregateRatio, aggregateStart, aggregateEnd, ringColors, aggregateColor } = buildRingsChart(groupItems, now);
+        const { svg, aggregate, ringColors } = buildRingsChart(groupItems, now);
         const chartShell = document.createElement('div');
         chartShell.className = 'chart-shell';
         chartShell.appendChild(svg);
         ringsPanel.appendChild(chartShell);
 
-        const overallWindow = document.createElement('div');
-        overallWindow.className = 'overall-window';
-        overallWindow.textContent = formatOverallWindow(aggregateStart, aggregateEnd);
-        ringsPanel.appendChild(overallWindow);
-        const overallCountdown = document.createElement('div');
-        overallCountdown.className = 'overall-countdown';
-        overallCountdown.textContent = describeRange(aggregateStart, aggregateEnd, now);
-        ringsPanel.appendChild(overallCountdown);
-        const overallLegend = document.createElement('div');
-        overallLegend.className = 'overall-legend';
-        overallLegend.textContent = 'Overall ring & slider cover all milestones below';
-        overallLegend.style.setProperty('--aggregate-color', aggregateColor);
-        ringsPanel.appendChild(overallLegend);
+        if (aggregate) {
+          const overallWindow = document.createElement('div');
+          overallWindow.className = 'overall-window';
+          overallWindow.textContent = formatOverallWindow(aggregate.start, aggregate.end);
+          ringsPanel.appendChild(overallWindow);
+          const overallCountdown = document.createElement('div');
+          overallCountdown.className = 'overall-countdown';
+          overallCountdown.textContent = describeRange(aggregate.start, aggregate.end, now);
+          ringsPanel.appendChild(overallCountdown);
+        }
 
         body.appendChild(ringsPanel);
 
         const list = document.createElement('ul');
         list.className = 'milestone-list';
-        const overallItem = document.createElement('li');
-        overallItem.className = 'milestone-item overall-item';
+        if (aggregate) {
+          const overallItem = document.createElement('li');
+          overallItem.className = 'milestone-item overall-item';
 
-        const overallSwatch = document.createElement('span');
-        overallSwatch.className = 'swatch';
-        overallSwatch.style.setProperty('--swatch', aggregateColor);
-        overallItem.appendChild(overallSwatch);
+          const overallSwatch = document.createElement('span');
+          overallSwatch.className = 'swatch';
+          overallSwatch.style.setProperty('--swatch', aggregate.color);
+          overallItem.appendChild(overallSwatch);
 
-        const overallText = document.createElement('div');
-        overallText.className = 'legend-text';
+          const overallText = document.createElement('div');
+          overallText.className = 'legend-text';
 
-        const overallTitle = document.createElement('span');
-        overallTitle.className = 'legend-title';
-        const milestoneNames = groupItems.map(item => item.title).join(', ');
-        overallTitle.textContent = `Overall (${milestoneNames})`;
-        overallText.appendChild(overallTitle);
+          const overallTitle = document.createElement('span');
+          overallTitle.className = 'legend-title';
+          const milestoneNames = groupItems.map(item => item.title).join(', ');
+          overallTitle.textContent = `Overall (${milestoneNames})`;
+          overallText.appendChild(overallTitle);
 
-        const overallWindowLine = document.createElement('span');
-        overallWindowLine.className = 'legend-window';
-        overallWindowLine.textContent = formatOverallWindow(aggregateStart, aggregateEnd);
-        overallText.appendChild(overallWindowLine);
+          const overallWindowLine = document.createElement('span');
+          overallWindowLine.className = 'legend-window';
+          overallWindowLine.textContent = formatOverallWindow(aggregate.start, aggregate.end);
+          overallText.appendChild(overallWindowLine);
 
-        const overallCountdownLine = document.createElement('span');
-        overallCountdownLine.className = 'legend-countdown';
-        overallCountdownLine.textContent = describeRange(aggregateStart, aggregateEnd, now);
-        overallText.appendChild(overallCountdownLine);
+          const overallCountdownLine = document.createElement('span');
+          overallCountdownLine.className = 'legend-countdown';
+          overallCountdownLine.textContent = describeRange(aggregate.start, aggregate.end, now);
+          overallText.appendChild(overallCountdownLine);
 
-        overallItem.appendChild(overallText);
+          overallItem.appendChild(overallText);
 
-        const overallPercentLabel = document.createElement('span');
-        overallPercentLabel.className = 'legend-percent';
-        overallPercentLabel.style.setProperty('color', aggregateColor);
-        overallPercentLabel.textContent = `${Math.round(aggregateRatio * 100)}%`;
-        overallItem.appendChild(overallPercentLabel);
+          const overallPercentLabel = document.createElement('span');
+          overallPercentLabel.className = 'legend-percent';
+          overallPercentLabel.style.setProperty('color', aggregate.color);
+          overallPercentLabel.textContent = `${Math.round(aggregate.ratio * 100)}%`;
+          overallItem.appendChild(overallPercentLabel);
 
-        const overallProgress = document.createElement('div');
-        overallProgress.className = 'progress-bar';
-        overallProgress.setAttribute('aria-label', `${Math.round(aggregateRatio * 100)}% of the category window consumed`);
-        const overallProgressFill = document.createElement('span');
-        overallProgressFill.style.setProperty('--w', `${(aggregateRatio * 100).toFixed(1)}%`);
-        overallProgressFill.style.setProperty('--slider-color', aggregateColor);
-        overallProgress.appendChild(overallProgressFill);
-        overallItem.appendChild(overallProgress);
+          const overallProgress = document.createElement('div');
+          overallProgress.className = 'progress-bar';
+          overallProgress.setAttribute('aria-label', `${Math.round(aggregate.ratio * 100)}% of the category window consumed`);
+          const overallProgressFill = document.createElement('span');
+          overallProgressFill.style.setProperty('--w', `${(aggregate.ratio * 100).toFixed(1)}%`);
+          overallProgressFill.style.setProperty('--slider-color', aggregate.color);
+          overallProgress.appendChild(overallProgressFill);
+          overallItem.appendChild(overallProgress);
 
-        list.appendChild(overallItem);
+          list.appendChild(overallItem);
+        }
         groupItems.forEach((item, index) => {
           const li = document.createElement('li');
           li.className = 'milestone-item';

--- a/milestones-radiator.html
+++ b/milestones-radiator.html
@@ -11,7 +11,7 @@
          - start (optional ISO date or date-time: "2024-06-01" or "2024-06-01T09:00")
          - end (optional ISO date or date-time when the milestone finishes)
          - category (optional short label for grouping; colors are assigned automatically)
-       Omit "start" to default the milestone to "now".
+       Omit "start" to default the milestone to `ProjectStartDate` (set below).
 
     2. To embed this radiator inside an Azure DevOps Wiki page, open the file in a
        browser, copy the full HTML (Ctrl+A, Ctrl+C) and paste it into the Wiki editor.
@@ -244,6 +244,8 @@
       { title: "Pillar 2 Rating CR", url: "https://example.com/training", end: "2025-12-05", category: "CR" }
     ];
 
+    const ProjectStartDate = new Date('2025-07-14T00:00:00');
+
     const MS = {
       minute: 60 * 1000,
       hour: 60 * 60 * 1000,
@@ -261,19 +263,21 @@
       return isNaN(parsed.getTime()) ? null : parsed;
     }
 
-    function normalizeMilestone(milestone, fallbackStart) {
+    function normalizeMilestone(milestone) {
       const parsedStart = milestone.start ? parseDate(milestone.start) : null;
       const explicitStart = Boolean(parsedStart);
-      const start = parsedStart || new Date(fallbackStart);
+      const start = parsedStart ? new Date(parsedStart) : new Date(ProjectStartDate);
       const end = milestone.end ? parseDate(milestone.end) : null;
       return { ...milestone, start, end, hasExplicitStart: explicitStart };
     }
 
     function classifyMilestone({ start, end, hasExplicitStart }, now) {
       if (!hasExplicitStart && !end) return 'unknown';
-      const effectiveStart = hasExplicitStart ? start : now;
+      const effectiveStart = hasExplicitStart ? start : ProjectStartDate;
       const effectiveEnd = end || new Date(effectiveStart.getTime() + MS.day);
-      if (now < effectiveStart) return 'pending';
+      if (now < effectiveStart) {
+        return hasExplicitStart ? 'pending' : 'active';
+      }
       if (now > effectiveEnd) return 'done';
       return 'active';
     }
@@ -315,8 +319,14 @@
     function describeCountdown(milestone, now) {
       const { start, end, hasExplicitStart } = milestone;
       if (!hasExplicitStart && !end) return 'Invalid date';
-      const effectiveStart = hasExplicitStart ? start : now;
+      const effectiveStart = hasExplicitStart ? start : ProjectStartDate;
       const effectiveEnd = end || new Date(effectiveStart.getTime() + MS.day);
+      if (!hasExplicitStart) {
+        if (now <= effectiveEnd) {
+          return `Ends in ${formatRelative(effectiveEnd - now)}`;
+        }
+        return `Finished ${formatRelative(now - effectiveEnd)} ago`;
+      }
       if (now < effectiveStart) {
         return `Begins in ${formatRelative(effectiveStart - now)}`;
       }
@@ -329,13 +339,15 @@
     function progressValue(milestone, now) {
       const { start, end, hasExplicitStart } = milestone;
       if (!hasExplicitStart && !end) return 0;
-      const effectiveStart = hasExplicitStart ? start : now;
+      const effectiveStart = hasExplicitStart ? start : ProjectStartDate;
       const effectiveEnd = end || new Date(effectiveStart.getTime() + MS.day);
-      if (now >= effectiveEnd) return 0;
-      if (now <= effectiveStart) return 1;
+      if (now >= effectiveEnd) return 1;
       const total = Math.max(effectiveEnd - effectiveStart, MS.minute);
-      const remaining = Math.max(0, effectiveEnd - now);
-      return Math.min(1, Math.max(0, remaining / total));
+      if (now <= effectiveStart) {
+        return 0;
+      }
+      const elapsed = Math.max(0, Math.min(total, now - effectiveStart));
+      return Math.min(1, elapsed / total);
     }
 
     function statusLabel(status) {
@@ -388,7 +400,7 @@
       radiator.innerHTML = '';
       completedRadiator.innerHTML = '';
       const items = milestones
-        .map((milestone) => normalizeMilestone(milestone, now))
+        .map((milestone) => normalizeMilestone(milestone))
         .sort((a, b) => (a.start || 0) - (b.start || 0));
 
       const categoryColors = buildCategoryColors(items);
@@ -412,7 +424,7 @@
         const progress = status === 'unknown' ? 0 : progressValue(item, now);
         const progressPercent = Math.round(progress * 100);
         const progressBar = node.querySelector('.progress-bar');
-        progressBar.setAttribute('aria-label', `${progressPercent}% of the time window remaining`);
+        progressBar.setAttribute('aria-label', `${progressPercent}% of the time window consumed`);
         progressBar.querySelector('span').style.setProperty('--w', `${progressPercent}%`);
 
         const badge = node.querySelector('.category');

--- a/milestones-radiator.html
+++ b/milestones-radiator.html
@@ -341,13 +341,13 @@
       if (!hasExplicitStart && !end) return 0;
       const effectiveStart = hasExplicitStart ? start : ProjectStartDate;
       const effectiveEnd = end || new Date(effectiveStart.getTime() + MS.day);
-      if (now >= effectiveEnd) return 1;
+      if (now >= effectiveEnd) return 0;
       const total = Math.max(effectiveEnd - effectiveStart, MS.minute);
       if (now <= effectiveStart) {
-        return 0;
+        return 1;
       }
-      const elapsed = Math.max(0, Math.min(total, now - effectiveStart));
-      return Math.min(1, elapsed / total);
+      const remaining = Math.max(0, Math.min(total, effectiveEnd - now));
+      return Math.min(1, remaining / total);
     }
 
     function statusLabel(status) {
@@ -424,7 +424,7 @@
         const progress = status === 'unknown' ? 0 : progressValue(item, now);
         const progressPercent = Math.round(progress * 100);
         const progressBar = node.querySelector('.progress-bar');
-        progressBar.setAttribute('aria-label', `${progressPercent}% of the time window consumed`);
+        progressBar.setAttribute('aria-label', `${progressPercent}% of the time window remaining`);
         progressBar.querySelector('span').style.setProperty('--w', `${progressPercent}%`);
 
         const badge = node.querySelector('.category');

--- a/milestones-radiator.html
+++ b/milestones-radiator.html
@@ -238,10 +238,10 @@
 
   <script>
     const milestones = [
-      { title: "Regional teams kick-off", url: "https://example.com/kickoff", start: "2024-05-28T09:00", category: "Launch" },
-      { title: "Prototype review", url: "https://example.com/prototype", start: "2024-06-10", end: "2024-06-14", category: "Design" },
-      { title: "MVP delivery", url: "https://example.com/mvp", start: "2024-07-01", end: "2024-07-05", category: "Product" },
-      { title: "Key user training", url: "https://example.com/training", start: "2024-07-12", category: "Adoption" }
+      { title: "MVP 1", url: "https://example.com/kickoff", end: "2025-10-17", category: "MVP" },
+      { title: "MVP 2", url: "https://example.com/prototype", end: "2025-11-14", category: "MVP" },
+      { title: "Release Sprint", url: "https://example.com/mvp", start: "2025-11-17", end: "2025-11-28", category: "Release" },
+      { title: "Pillar 2 Rating CR", url: "https://example.com/training", end: "2025-12-05", category: "CR" }
     ];
 
     const MS = {
@@ -262,22 +262,29 @@
     }
 
     function normalizeMilestone(milestone, fallbackStart) {
-      const start = milestone.start ? parseDate(milestone.start) : new Date(fallbackStart);
+      const parsedStart = milestone.start ? parseDate(milestone.start) : null;
+      const explicitStart = Boolean(parsedStart);
+      const start = parsedStart || new Date(fallbackStart);
       const end = milestone.end ? parseDate(milestone.end) : null;
-      return { ...milestone, start, end };
+      return { ...milestone, start, end, hasExplicitStart: explicitStart };
     }
 
-    function classifyMilestone({ start, end }, now) {
-      if (!start) return 'unknown';
-      const effectiveEnd = end || new Date(start.getTime() + MS.day);
-      if (now < start) return 'pending';
+    function classifyMilestone({ start, end, hasExplicitStart }, now) {
+      if (!hasExplicitStart && !end) return 'unknown';
+      const effectiveStart = hasExplicitStart ? start : now;
+      const effectiveEnd = end || new Date(effectiveStart.getTime() + MS.day);
+      if (now < effectiveStart) return 'pending';
       if (now > effectiveEnd) return 'done';
       return 'active';
     }
 
-    function formatWindow({ start, end }) {
-      if (!start) return 'Date to be confirmed';
+    function formatWindow({ start, end, hasExplicitStart }) {
+      if (!hasExplicitStart && !end) return 'Date to be confirmed';
       const localeOpts = { day: '2-digit', month: 'short', year: 'numeric' };
+      if (!hasExplicitStart && end) {
+        const endStr = end.toLocaleString('en-US', localeOpts);
+        return `\u25CF Until ${endStr}`;
+      }
       const startStr = start.toLocaleString('en-US', localeOpts);
       if (!end) {
         return `\u25CF ${startStr}`;
@@ -306,25 +313,29 @@
     }
 
     function describeCountdown(milestone, now) {
-      const { start, end } = milestone;
-      if (!start) return 'Invalid date';
-      const effectiveEnd = end || new Date(start.getTime() + MS.day);
-      if (now < start) {
-        return `Starts in ${formatRelative(start - now)}`;
+      const { start, end, hasExplicitStart } = milestone;
+      if (!hasExplicitStart && !end) return 'Invalid date';
+      const effectiveStart = hasExplicitStart ? start : now;
+      const effectiveEnd = end || new Date(effectiveStart.getTime() + MS.day);
+      if (now < effectiveStart) {
+        return `Begins in ${formatRelative(effectiveStart - now)}`;
       }
       if (now <= effectiveEnd) {
-        return `Time remaining ${formatRelative(effectiveEnd - now)}`;
+        return `Ends in ${formatRelative(effectiveEnd - now)}`;
       }
       return `Finished ${formatRelative(now - effectiveEnd)} ago`;
     }
 
     function progressValue(milestone, now) {
-      const { start, end } = milestone;
-      if (!start) return 0;
-      if (now <= start) return 0;
-      const effectiveEnd = end || new Date(start.getTime() + MS.day);
-      if (now >= effectiveEnd) return 1;
-      return (now - start) / (effectiveEnd - start);
+      const { start, end, hasExplicitStart } = milestone;
+      if (!hasExplicitStart && !end) return 0;
+      const effectiveStart = hasExplicitStart ? start : now;
+      const effectiveEnd = end || new Date(effectiveStart.getTime() + MS.day);
+      if (now >= effectiveEnd) return 0;
+      if (now <= effectiveStart) return 1;
+      const total = Math.max(effectiveEnd - effectiveStart, MS.minute);
+      const remaining = Math.max(0, effectiveEnd - now);
+      return Math.min(1, Math.max(0, remaining / total));
     }
 
     function statusLabel(status) {
@@ -399,7 +410,10 @@
         node.querySelector('.countdown').textContent = describeCountdown(item, now);
         node.querySelector('.window').textContent = formatWindow(item);
         const progress = status === 'unknown' ? 0 : progressValue(item, now);
-        node.querySelector('.progress-bar span').style.setProperty('--w', `${Math.round(progress * 100)}%`);
+        const progressPercent = Math.round(progress * 100);
+        const progressBar = node.querySelector('.progress-bar');
+        progressBar.setAttribute('aria-label', `${progressPercent}% of the time window remaining`);
+        progressBar.querySelector('span').style.setProperty('--w', `${progressPercent}%`);
 
         const badge = node.querySelector('.category');
         if (item.category) {


### PR DESCRIPTION
## Summary
- update the standalone FlowingData-style milestones radiator to calculate remaining time for progress bars using the October–December 2025 milestones provided
- add a radial countdown variant that presents remaining time as conic gradients with percentage badges for each milestone
- add a time-block grid variant that maps the remaining days for every milestone onto a FlowingData-inspired day mosaic

## Testing
- not run (static assets only)


------
https://chatgpt.com/codex/tasks/task_e_68ca96ac35c0832ea8754844eec3c6c0